### PR TITLE
docs: adoptar plantilla de documentación y gobernanza

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig — https://editorconfig.org
+# Ayuda a mantener un estilo de código consistente entre editores.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.{py,go}]
+indent_size = 4

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# ==============================================================================
+# Variables de entorno — TechWorld Learning Platform
+# ==============================================================================
+# Copia este archivo a `.env` y completa los valores para tu entorno.
+#   cp .env.example .env
+#
+# NUNCA subas tu archivo `.env` con valores reales al repositorio.
+# Ver SECURITY.md y docs/conventions/secrets.md.
+# ==============================================================================
+
+# ── Django ────────────────────────────────────────────────────────────────
+# Clave secreta de Django (genera una aleatoria y larga para producción)
+SECRET_KEY=django-super-secret-key
+# Modo debug: "True" en desarrollo, "False" en producción
+DEBUG=True
+
+# ── Base de datos (PostgreSQL) ──────────────────────────────────────────────
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=techworld
+DB_USER=tu_usuario
+DB_PASSWORD=tu_contraseña

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,8 @@
+# Configura los canales de patrocinio que aparecen en tu repositorio.
+# Borra los que no uses. Documentación:
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: brayandiazc
+# ko_fi: usuario_kofi
+# patreon: usuario_patreon
+# custom: ["https://ejemplo.com/apoyar"]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Reporte de Bug
+about: Informa sobre un error o comportamiento inesperado
+title: "[BUG]: "
+labels: ["bug"]
+assignees: []
+---
+
+## Descripción del Bug
+
+Describe claramente el problema que has encontrado.
+
+## Pasos para Reproducir
+
+1. Ve a '...'
+2. Haz clic en '....'
+3. Desplázate a '....'
+4. Mira el error
+
+## Comportamiento Esperado
+
+Describe lo que esperabas que sucediera.
+
+## Comportamiento Actual
+
+Describe lo que realmente sucede.
+
+## Capturas de Pantalla (opcional)
+
+Si es posible, adjunta capturas de pantalla para ayudar a explicar tu problema.
+
+## Entorno (por favor completa lo siguiente)
+
+- **Dispositivo**: [Ej. iPhone 13, Samsung Galaxy S22]
+- **Sistema Operativo**: [Ej. iOS 15, Android 12]
+- **Versión de la App**: [Ej. v1.0.0]
+
+## Información Adicional (opcional)
+
+Añade cualquier otro contexto sobre el problema aquí.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentación del Proyecto
+    url: "https://github.com/brayandiazc/inforcap-techworld-django/wiki"
+    about: Consulta la documentación completa del proyecto
+  - name: Discusiones de la Comunidad
+    url: "https://github.com/brayandiazc/inforcap-techworld-django/discussions"
+    about: Únete a las discusiones para hacer preguntas generales

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,37 @@
+---
+name: Solicitud de Documentación
+about: Solicitar mejoras o actualizaciones en la documentación
+title: "[DOC] "
+labels: documentation
+assignees: ""
+---
+
+## Documentación a Actualizar
+
+Archivo o sección específica: (ej. `README.md`, `docs/api.md`)
+
+## Problema Actual
+
+Describe qué está incompleto, desactualizado o confuso en la documentación actual.
+
+## Mejora Propuesta
+
+Qué debería agregarse o modificarse:
+
+- [ ] Explicaciones o aclaraciones
+- [ ] Ejemplos de código
+- [ ] Guías paso a paso
+- [ ] Diagramas o capturas
+- [ ] Referencias a APIs
+- [ ] Otro:
+
+## Audiencia Objetivo
+
+- [ ] Desarrolladores
+- [ ] Usuarios finales
+- [ ] Administradores de sistema
+- [ ] Otro:
+
+## Contexto Adicional
+
+Referencias externas, ejemplos de otras documentaciones, o detalles adicionales relevantes.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Nueva Funcionalidad
+about: Proponer una nueva característica o mejora
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## Problema o Necesidad
+
+Describe qué problema resuelve esta funcionalidad o qué necesidad cubre.
+
+## Solución Propuesta
+
+Descripción detallada de la funcionalidad y cómo debería funcionar.
+
+## Alternativas Consideradas
+
+Otras soluciones evaluadas y por qué se prefiere la propuesta principal.
+
+## Especificaciones Técnicas
+
+- **Frontend**: Cambios en UI/UX necesarios
+- **Backend**: Modificaciones en lógica de negocio
+- **Base de datos**: Cambios en esquema o modelos
+- **Dependencias**: Nuevas librerías o servicios requeridos
+
+## Impacto
+
+- **Usuarios**: Cómo afecta la experiencia del usuario
+- **Rendimiento**: Impacto esperado en performance
+- **Mantenibilidad**: Complejidad añadida al sistema
+
+## Riesgos y Consideraciones
+
+Posibles dificultades, limitaciones o efectos secundarios de la implementación.

--- a/.github/ISSUE_TEMPLATE/support_question.md
+++ b/.github/ISSUE_TEMPLATE/support_question.md
@@ -1,0 +1,37 @@
+---
+name: Soporte Técnico
+about: Solicitar ayuda o resolver dudas sobre el uso del sistema
+title: "[SUPPORT] "
+labels: question, support
+assignees: ""
+---
+
+## Pregunta o Problema
+
+Descripción clara del problema o duda.
+
+## Qué Intentas Lograr
+
+Objetivo o resultado que buscas obtener.
+
+## Pasos Realizados
+
+1.
+2.
+3.
+
+## Entorno
+
+- **Sistema Operativo**:
+- **Versión del Proyecto**:
+- **Otros**: (navegador, runtime, configuraciones relevantes)
+
+## Soluciones Intentadas
+
+- [ ] Revisé la documentación
+- [ ] Busqué en issues existentes
+- [ ] Probé soluciones alternativas: (describir)
+
+## Información Adicional
+
+Capturas de pantalla, mensajes de error, logs o referencias consultadas.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,35 @@
+---
+name: Tarea
+about: Crear una tarea específica de trabajo
+title: "[TASK] "
+labels: task
+assignees: ""
+---
+
+## Descripción
+
+Qué se debe realizar y por qué es necesario.
+
+## Resultado Esperado
+
+Criterios de éxito y entregables esperados.
+
+## Acciones Requeridas
+
+- [ ] Acción 1
+- [ ] Acción 2
+- [ ] Acción 3
+
+## Dependencias
+
+- Issues relacionados: #
+- Tareas previas requeridas:
+- Recursos necesarios:
+
+## Impacto
+
+Cómo beneficia esta tarea al proyecto (eficiencia, calidad, rendimiento, etc.)
+
+## Contexto Adicional
+
+Documentación relevante, referencias o información complementaria.

--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,0 +1,62 @@
+# Configuración de Labels en GitHub
+
+Los labels categorizan Issues y Pull Requests. El archivo [`labeler.yml`](labeler.yml)
+asigna automáticamente labels a los PRs según los archivos modificados.
+
+## Labels Automáticos (asignados por labeler)
+
+Deben existir en el repositorio para que el labeler funcione.
+
+| Label           | Color     | Descripción                             |
+| --------------- | --------- | --------------------------------------- |
+| `documentation` | `#0075CA` | Cambios en documentación                |
+| `frontend`      | `#0052CC` | Cambios en UI / cliente                 |
+| `styles`        | `#BFD4F2` | Cambios en CSS / estilos                |
+| `backend`       | `#006B75` | Cambios en servidor / API / lógica      |
+| `database`      | `#5319E7` | Migraciones, esquema o seeds            |
+| `testing`       | `#FBCA04` | Cambios en tests                        |
+| `dependencies`  | `#0366D6` | Actualizaciones de dependencias         |
+| `config`        | `#D4C5F9` | Cambios en configuración                |
+| `ci-cd`         | `#F9D0C4` | Cambios en CI/CD, workflows y Docker    |
+| `github`        | `#333333` | Cambios en templates y config de GitHub |
+
+## Labels Manuales
+
+| Label              | Color     | Descripción                       |
+| ------------------ | --------- | --------------------------------- |
+| `bug`              | `#D73A4A` | Algo no funciona correctamente    |
+| `enhancement`      | `#A2EEEF` | Nueva funcionalidad o mejora      |
+| `breaking change`  | `#B60205` | Cambios que rompen compatibilidad |
+| `needs review`     | `#FBCA04` | Requiere revisión                 |
+| `work in progress` | `#FEF2C0` | Trabajo en progreso               |
+| `ready for merge`  | `#0E8A16` | Aprobado y listo para merge       |
+| `blocked`          | `#B60205` | Bloqueado por dependencias        |
+| `help wanted`      | `#008672` | Se necesita ayuda externa         |
+| `good first issue` | `#7057FF` | Bueno para nuevos contribuidores  |
+| `duplicate`        | `#CFD3D7` | Issue o PR duplicado              |
+| `invalid`          | `#E4E669` | No es válido o no procede         |
+| `wontfix`          | `#FFFFFF` | No se trabajará en esto           |
+| `question`         | `#D876E3` | Solicitud de información          |
+
+## Crear Labels
+
+### Opción 1: Script automático (recomendado)
+
+```bash
+gh auth login
+bash .github/scripts/setup-labels.sh
+```
+
+### Opción 2: Manual en GitHub
+
+1. Ve a tu repositorio → **Issues** → **Labels**.
+2. Click en **New label**.
+3. Crea cada label con el nombre, color y descripción de las tablas anteriores.
+
+## Personalizar
+
+Para agregar un nuevo label automático:
+
+1. Crea el label en GitHub (manual o con el script).
+2. Agrega la regla en [`labeler.yml`](labeler.yml).
+3. Documéntalo en este archivo y en `setup-labels.sh`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+# Descripción
+
+Resumen de los cambios y qué problema resuelven.
+
+## Tipo de Cambio
+
+- [ ] Bug fix
+- [ ] Nueva funcionalidad
+- [ ] Breaking change
+- [ ] Refactorización
+- [ ] Documentación
+- [ ] Configuración / DevOps
+
+## Cambios Realizados
+
+**Antes**: Comportamiento actual del sistema.
+
+**Después**: Nuevo comportamiento implementado.
+
+## Instrucciones de Prueba
+
+1.
+2.
+3.
+
+## Checklist
+
+- [ ] El código sigue las guías de estilo del proyecto
+- [ ] Auto-revisión completada
+- [ ] Código comentado en secciones complejas
+- [ ] Tests ejecutados exitosamente
+- [ ] Tests nuevos añadidos (si aplica)
+- [ ] Sin regresiones en funcionalidad existente
+- [ ] Documentación actualizada (si aplica)
+
+## Issues Relacionados
+
+Closes #
+Relates to #
+
+## Impacto
+
+- **Performance**: Ninguno / Mejora / Degradación
+- **Breaking changes**: Sí / No
+- **Requiere migración**: Sí / No
+
+## Evidencia
+
+Screenshots, GIFs o videos demostrando los cambios (si aplica).
+
+## Notas para Revisores
+
+Áreas específicas que requieren atención o decisiones de diseño tomadas.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# ==============================================================================
+# Configuración de Dependabot
+# ==============================================================================
+# Dependabot revisa tus dependencias y abre PRs para actualizarlas.
+# Documentación: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+#
+# AJUSTA los `package-ecosystem` a los que use tu proyecto. Abajo se incluyen
+# github-actions (casi siempre útil) y un ejemplo comentado por ecosistema.
+# ==============================================================================
+
+version: 2
+
+updates:
+  # GitHub Actions usadas en los workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci-cd"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # Dependencias de Python (requirements.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # ── Otros ecosistemas — descomenta el que corresponda ─────────────────────
+  #
+  # - package-ecosystem: "npm"        # Node.js
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   labels: ["dependencies"]
+  #
+  # - package-ecosystem: "bundler"    # Ruby
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #
+  # - package-ecosystem: "gomod"      # Go
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #
+  # - package-ecosystem: "docker"     # Dockerfile
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,82 @@
+# Auto-etiquetado de Pull Requests según los archivos modificados.
+# Reglas genéricas por ruta — ajústalas a la estructura real de tu proyecto.
+
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/*.md"
+      - "docs/**/*"
+      - ".github/ISSUE_TEMPLATE/**/*"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+
+frontend:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/**/*"
+      - "app/**/*"
+      - "public/**/*"
+
+styles:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/*.css"
+      - "**/*.scss"
+      - "**/*.sass"
+
+backend:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "server/**/*"
+      - "api/**/*"
+      - "lib/**/*"
+
+database:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/migrations/**/*"
+      - "**/migrate/**/*"
+      - "**/*.sql"
+      - "**/seeds.*"
+
+testing:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "test/**/*"
+      - "tests/**/*"
+      - "spec/**/*"
+      - "**/*.test.*"
+      - "**/*_test.*"
+      - "**/*_spec.*"
+
+config:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "config/**/*"
+      - ".env*"
+      - "*.config.*"
+
+ci-cd:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".github/workflows/**/*"
+      - ".github/dependabot.yml"
+      - "Dockerfile*"
+      - "docker-compose*"
+
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "package.json"
+      - "package-lock.json"
+      - "yarn.lock"
+      - "pnpm-lock.yaml"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - "Gemfile*"
+      - "go.mod"
+      - "go.sum"
+
+github:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".github/**/*"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,29 @@
+# Workflows de CI/CD
+
+Esta carpeta contiene los workflows de [GitHub Actions](https://docs.github.com/actions)
+del proyecto.
+
+Como la plantilla es agnóstica del stack, **no incluye workflows listos para
+ejecutar**: solo un esqueleto de ejemplo. Adáptalo (o créalo) según tu lenguaje
+y herramientas.
+
+## Esqueleto incluido
+
+- [`ci.example.yml`](ci.example.yml) — pipeline de CI neutro (lint → test → build).
+  Tiene la extensión `.example` **a propósito** para que GitHub no lo ejecute.
+  Cuando lo adaptes a tu stack, renómbralo a `ci.yml`.
+
+## Workflows recomendados
+
+| Workflow                    | Propósito                                      |
+| --------------------------- | ---------------------------------------------- |
+| `ci.yml`                    | Lint, tests y build en cada push/PR.           |
+| `labeler.yml`               | Auto-etiquetado de PRs (usa `../labeler.yml`). |
+| `dependabot-auto-merge.yml` | Auto-merge de PRs de Dependabot (parches).     |
+| `deploy.yml`                | Despliegue (depende de tu infraestructura).    |
+
+## Secrets
+
+Define en **Settings → Secrets and variables → Actions** los secretos que
+necesiten tus workflows (claves de deploy, tokens, etc.). Ver
+[`../../docs/conventions/secrets.md`](../../docs/conventions/secrets.md).

--- a/.github/workflows/ci.example.yml
+++ b/.github/workflows/ci.example.yml
@@ -1,0 +1,70 @@
+# ==============================================================================
+# Esqueleto de CI para Django — DESACTIVADO por defecto.
+# Renómbralo a `ci.yml` para activarlo. Mientras tenga la extensión `.example`,
+# GitHub Actions no lo ejecuta. Ajusta versiones y comandos a tu gusto.
+# ==============================================================================
+
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Instalar dependencias
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install ruff
+      - name: Lint
+        run: ruff check .
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    services:
+      db:
+        image: postgres:16
+        env:
+          POSTGRES_DB: techworld
+          POSTGRES_USER: techworld
+          POSTGRES_PASSWORD: techworld
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      SECRET_KEY: ci-secret-key
+      DEBUG: "True"
+      DB_HOST: localhost
+      DB_PORT: "5432"
+      DB_NAME: techworld
+      DB_USER: techworld
+      DB_PASSWORD: techworld
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Instalar dependencias
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Migraciones
+        run: python manage.py migrate
+      - name: Tests
+        run: python manage.py test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+Todos los cambios notables de este proyecto se documentan en este archivo.
+
+El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/)
+y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.0.0] - 2026-07-02
+
+### Added
+
+- Gestión de usuarios (app `users`): registro con contraseña hasheada e inicio de sesión.
+- Gestión de cursos (app `courses`): listado, creación e inscripción de estudiantes con control de duplicados (`unique_together`).
+- Modelo de datos con las entidades `User`, `Course` e `Inscription` (con progreso).
+- Panel de administración de Django para usuarios, cursos e inscripciones.
+- Datos iniciales cargables mediante fixtures (`loaddata`).
+- Plantillas con Django Templates + Bootstrap (herencia de `base.html` y `navbar.html`).
+- Configuración por variables de entorno con `python-dotenv` (`.env.example`).
+- Documentación del proyecto y de gobernanza a partir de la plantilla
+  [`project-starter-template-es`](https://github.com/brayandiazc/project-starter-template-es):
+  `docs/` (arquitectura, producto, convenciones y decisiones), `CONTRIBUTING`,
+  `CODE_OF_CONDUCT`, `SECURITY`, `LICENSE` (MIT), `.editorconfig` y plantillas de
+  issues/PR en `.github/`.
+
+<!--
+Enlaces de comparación entre versiones:
+[Unreleased]: https://github.com/brayandiazc/inforcap-techworld-django/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/brayandiazc/inforcap-techworld-django/releases/tag/v1.0.0
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Código de Conducta
+
+Este proyecto adopta el [Contributor Covenant](https://www.contributor-covenant.org/es/version/2/1/code_of_conduct/) versión 2.1 como base para fomentar una comunidad abierta y acogedora.
+
+## Nuestra promesa
+
+Nos comprometemos a hacer que la participación en nuestro proyecto sea una experiencia libre de acoso para todos, sin importar edad, tamaño corporal, discapacidad, etnia, características sexuales, identidad y expresión de género, nivel de experiencia, educación, estatus socioeconómico, nacionalidad, apariencia personal, raza, religión o identidad u orientación sexual.
+
+## Nuestro estándar
+
+Ejemplos de comportamiento que contribuyen a crear un entorno positivo:
+
+- Uso de un lenguaje amable e inclusivo.
+- Respeto a diferentes puntos de vista y experiencias.
+- Aceptación de críticas constructivas con gracia.
+- Foco en lo que es mejor para la comunidad.
+
+Comportamientos inaceptables:
+
+- Uso de lenguaje o imágenes sexualizadas.
+- Comentarios insultantes o despectivos y ataques personales o políticos.
+- Acoso público o privado.
+- Publicar información privada de terceros sin su permiso.
+
+## Aplicación
+
+Los casos de comportamiento abusivo, de acoso o inaceptable pueden ser reportados al equipo del proyecto en <brayandiazc@gmail.com>. Todas las quejas serán revisadas e investigadas de manera oportuna y justa, manteniendo la confidencialidad de quien reporta.
+
+Los responsables del proyecto que no apliquen o no hagan cumplir este Código de Conducta de buena fe pueden enfrentar repercusiones temporales o permanentes según lo determine el liderazgo del proyecto.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,153 @@
+# Guía de Contribución
+
+¡Gracias por tu interés en contribuir a **TechWorld Learning Platform**! Esta guía describe el flujo de trabajo, los estándares de código y el proceso de Pull Requests.
+
+## Tabla de Contenidos
+
+- [Configuración del Entorno](#configuración-del-entorno)
+- [Flujo de Trabajo](#flujo-de-trabajo)
+- [Estándares de Código](#estándares-de-código)
+- [Commits y Mensajes](#commits-y-mensajes)
+- [Pull Requests](#pull-requests)
+- [Revisión de Código](#revisión-de-código)
+- [Testing](#testing)
+
+## Configuración del Entorno
+
+Sigue las instrucciones de instalación del [README](README.md#instalación). Asegúrate de que los tests pasen localmente antes de empezar a trabajar.
+
+## Flujo de Trabajo
+
+Usamos un flujo **Git Flow** simplificado.
+
+### Estrategia de Branching
+
+| Rama       | Propósito                                        | Origen    | Destino            |
+| ---------- | ------------------------------------------------ | --------- | ------------------ |
+| `main`     | Código en producción. Siempre estable.           | —         | —                  |
+| `develop`  | Integración de funcionalidades. Pre-release.     | `main`    | `main`             |
+| `feat/*`   | Nueva funcionalidad.                             | `develop` | `develop`          |
+| `fix/*`    | Corrección de bug no urgente.                    | `develop` | `develop`          |
+| `hotfix/*` | Corrección urgente en producción.                | `main`    | `main` y `develop` |
+| `docs/*`   | Cambios solo de documentación.                   | `develop` | `develop`          |
+| `chore/*`  | Tareas de mantenimiento, tooling, configuración. | `develop` | `develop`          |
+
+```mermaid
+gitGraph
+    commit
+    branch develop
+    checkout develop
+    commit
+    branch feat/nueva-funcionalidad
+    checkout feat/nueva-funcionalidad
+    commit
+    commit
+    checkout develop
+    merge feat/nueva-funcionalidad
+    checkout main
+    merge develop tag: "v1.0.0"
+```
+
+### Flujo de una funcionalidad
+
+```bash
+# 1. Parte de develop actualizado
+git checkout develop
+git pull origin develop
+
+# 2. Crea tu rama
+git checkout -b feat/nombre-descriptivo
+
+# 3. Trabaja y commitea (ver formato abajo)
+git add .
+git commit -m "feat: agrega X"
+
+# 4. Sube tu rama y abre un PR hacia develop
+git push origin feat/nombre-descriptivo
+```
+
+### Flujo de hotfix
+
+Los hotfix parten de `main`, se mergean a `main` y luego se sincronizan a `develop`.
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b hotfix/descripcion-del-fix
+# ... fix + commit ...
+git push origin hotfix/descripcion-del-fix
+```
+
+### Nombrado de ramas
+
+- En minúsculas, con prefijo de tipo y descripción en `kebab-case`: `feat/login-google`, `fix/timeout-pagos`, `docs/actualizar-readme`.
+
+### Políticas de ramas
+
+- `main` y `develop` están protegidas: no se permite push directo, solo vía PR aprobado.
+- Mantén tu rama actualizada con `develop` (rebase o merge) antes de abrir el PR.
+
+## Estándares de Código
+
+### Formato
+
+- Indentación y estilo definidos por [`.editorconfig`](.editorconfig) y el linter del proyecto.
+- Líneas de máximo 88 caracteres (estándar de `black`).
+- Codificación UTF-8, finales de línea LF.
+
+### Nombrado
+
+- Sigue las convenciones idiomáticas de Python 3.10+ (p. ej. `camelCase`/`snake_case`/`PascalCase` según corresponda).
+- Nombres descriptivos; evita abreviaturas crípticas.
+
+### Comentarios
+
+- Comenta el _por qué_, no el _qué_. El código debe explicarse solo.
+- Documenta las decisiones no obvias y enlaza al ADR correspondiente cuando aplique.
+
+## Commits y Mensajes
+
+Usamos [Conventional Commits](https://www.conventionalcommits.org/es/v1.0.0/):
+
+```
+<tipo>(<ámbito opcional>): <descripción breve en imperativo>
+
+<cuerpo opcional>
+
+<footer opcional: BREAKING CHANGE, Closes #123>
+```
+
+Tipos comunes: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`.
+
+Ejemplos:
+
+```
+feat(auth): agrega login con Google
+fix(api): corrige timeout en el endpoint de pagos
+docs: actualiza la guía de instalación
+```
+
+## Pull Requests
+
+- Usa la [plantilla de PR](.github/PULL_REQUEST_TEMPLATE.md) (se carga automáticamente).
+- Un PR por cambio lógico; mantenlos pequeños y enfocados.
+- Vincula los issues relacionados (`Closes #123`).
+- Asegúrate de que CI pase (tests, linting, build).
+
+## Revisión de Código
+
+**Como autor:**
+
+- Haz una auto-revisión antes de pedir review.
+- Responde a los comentarios y marca las conversaciones resueltas.
+
+**Como revisor:**
+
+- Sé respetuoso y específico; sugiere, no impongas.
+- Verifica correctitud, legibilidad, tests y posibles regresiones.
+
+## Testing
+
+- Acompaña cada cambio funcional con tests.
+- Ejecuta la suite completa antes de abrir el PR (`python manage.py test`).
+- Sigue las [convenciones de testing](docs/conventions/testing.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brayan Diaz C
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Sigue estas instrucciones para obtener una copia funcional del proyecto en tu m�
 1. **Clonar el repositorio:**
 
 ```bash
-git clone https://github.com/tu-repositorio/techworld.git
-cd techworld
+git clone https://github.com/brayandiazc/inforcap-techworld-django.git
+cd inforcap-techworld-django
 ```
 
 2. **Crear un entorno virtual:**
@@ -220,10 +220,30 @@ Accede a `http://127.0.0.1:8000`.
 - **Base de Datos:**
   - PostgreSQL
 
+## Documentación 📚
+
+La documentación del proyecto vive en la carpeta [`docs/`](docs/):
+
+- **Arquitectura:** [`docs/architecture/`](docs/architecture/) — stack, arquitectura, modelo de datos, autenticación, contrato de vistas y diseño.
+- **Producto:** [`docs/product/`](docs/product/) — modelo (educativo) y roadmap.
+- **Convenciones:** [`docs/conventions/`](docs/conventions/) — reglas reusables de base de datos, testing, secretos, deploy, etc.
+- **Decisiones (ADR):** [`docs/decisions/`](docs/decisions/) — registro de decisiones arquitectónicas.
+- **Glosario:** [`docs/glossary.md`](docs/glossary.md).
+
+## Contribuir 🤝
+
+- Lee la [guía de contribución](CONTRIBUTING.md) y el [código de conducta](CODE_OF_CONDUCT.md).
+- Para reportar vulnerabilidades, consulta la [política de seguridad](SECURITY.md).
+- Los cambios notables se registran en el [CHANGELOG](CHANGELOG.md).
+
 ## Versionado 📌
 
-Usamos [Git](https://git-scm.com) para el versionado. Ve las [etiquetas](https://github.com/your/project/tags) disponibles.
+Usamos [Git](https://git-scm.com) y [Semantic Versioning](https://semver.org/lang/es/) para el versionado. Ve las [etiquetas](https://github.com/brayandiazc/inforcap-techworld-django/tags) y los [releases](https://github.com/brayandiazc/inforcap-techworld-django/releases) disponibles.
 
 ## Autores ✒️
 
-- **[Brayan Diaz C]** - _Desarrollador principal_ - [GitHub](https://github.com/brayandiazc)
+- **Brayan Diaz C** - _Desarrollador principal_ - [GitHub](https://github.com/brayandiazc)
+
+## Licencia 📄
+
+Este proyecto está bajo la Licencia MIT. Consulta el archivo [LICENSE](LICENSE) para más detalles.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,174 @@
+# Política de Seguridad
+
+Este documento describe cómo reportar vulnerabilidades en **TechWorld Learning Platform** y qué prácticas de seguridad seguimos en el repositorio.
+
+## Tabla de Contenidos
+
+- [Reporte de Vulnerabilidades](#reporte-de-vulnerabilidades)
+  - [Información a incluir](#información-a-incluir)
+  - [Qué esperar](#qué-esperar)
+- [Versiones Soportadas](#versiones-soportadas)
+- [Alcance](#alcance)
+- [Fuera de Alcance](#fuera-de-alcance)
+- [Manejo de Secretos](#manejo-de-secretos)
+- [Dependencias](#dependencias)
+- [Prácticas de Desarrollo Seguro](#prácticas-de-desarrollo-seguro)
+- [Respuesta a Incidentes](#respuesta-a-incidentes)
+- [Reconocimientos](#reconocimientos)
+- [Contacto](#contacto)
+
+## Reporte de Vulnerabilidades
+
+Si descubres una vulnerabilidad de seguridad, **no abras un issue público**. Repórtala de forma privada a través de uno de estos canales:
+
+- **Email**: <brayandiazc@gmail.com> (preferido — usa un asunto que empiece con `Security:` para priorizarlo).
+- **GitHub Security Advisories**: pestaña _Security_ del repositorio → _Report a vulnerability_.
+
+### Información a incluir
+
+Para poder triagear y responder rápido, incluye:
+
+1. Descripción clara de la vulnerabilidad.
+2. Pasos para reproducirla (PoC si es posible).
+3. Impacto estimado (qué se puede comprometer).
+4. Versión / commit afectado.
+5. Sugerencia de mitigación (opcional).
+6. Si quieres crédito público en la corrección, indica nombre y handle.
+
+### Qué esperar
+
+| Etapa                              | Tiempo objetivo             |
+| ---------------------------------- | --------------------------- |
+| Acuse de recibo                    | 48 horas hábiles            |
+| Triage inicial y severidad         | 5 días hábiles              |
+| Corrección de severidad crítica    | 7 días                      |
+| Corrección de severidad alta       | 30 días                     |
+| Corrección de severidad media/baja | próxima release planificada |
+
+Nos comprometemos a confirmar la recepción, mantenerte informado del progreso, no tomar represalias legales contra reportes de buena fe y acreditarte en el changelog/advisory una vez publicada la corrección (si lo deseas).
+
+## Versiones Soportadas
+
+| Versión                 | Soporte de seguridad          |
+| ----------------------- | ----------------------------- |
+| `main` (rama principal) | Sí                            |
+| `develop` (integración) | Sí                            |
+| Releases / tags         | Se da soporte a la última versión publicada. |
+
+## Alcance
+
+Superficies **en alcance** para reportes de seguridad:
+
+- Código fuente del repositorio.
+- Aplicación desplegada en los dominios oficiales.
+- Endpoints HTTP/API expuestos por el proyecto.
+- Pipelines de CI/CD del repositorio (`.github/workflows/`).
+- Artefactos publicados oficialmente.
+
+Ejemplos de hallazgos de interés:
+
+- Inyecciones (SQL, comandos, plantillas, deserialización).
+- Cross-Site Scripting (XSS), CSRF, SSRF, clickjacking.
+- Autenticación rota o bypass de autorización.
+- Escalada de privilegios.
+- Exposición de datos sensibles (PII, claves de API, secretos).
+- Configuraciones inseguras (CORS, headers, cookies, TLS).
+- Vulnerabilidades en dependencias con impacto demostrable.
+- Race conditions con impacto en seguridad.
+- Path traversal, RCE, LFI/RFI.
+
+## Fuera de Alcance
+
+Los siguientes hallazgos **no califican** como vulnerabilidades:
+
+- Reportes de scanners automáticos sin impacto demostrado.
+- Ausencia de headers de seguridad sin un vector de explotación.
+- Self-XSS, ingeniería social, phishing.
+- Denegación de servicio (DoS / DDoS) por volumen de tráfico.
+- Vulnerabilidades en dependencias sin vector de explotación en este proyecto.
+- Versiones beta/desarrollo de software de terceros.
+- Divulgación de información ya pública.
+
+## Manejo de Secretos
+
+- **Nunca** commitear secretos en texto plano (claves de API, tokens, contraseñas, certificados privados, archivos `.env` con valores reales).
+- Gestiona los secretos con el mecanismo de tu stack (gestor de secretos, variables de entorno cifradas, etc.). Ver [`docs/conventions/secrets.md`](docs/conventions/secrets.md).
+- Comparte las credenciales fuera de banda con nuevos colaboradores (nunca por git, email en texto plano ni chat público).
+- En CI/CD, los secretos viven como **secrets cifrados** del proveedor (p. ej. GitHub Actions Secrets).
+- Rota credenciales periódicamente (sugerido cada **90 días**) y de inmediato ante sospecha de compromiso.
+- Si un secreto se commitea por error: **rota el secreto antes de limpiar la historia**. Reescribir la historia no es suficiente — asume que ya está comprometido.
+
+## Dependencias
+
+- Fija las versiones de dependencias con un lockfile versionado.
+- Ejecuta auditorías de vulnerabilidades automáticas en CI (`pip-audit`).
+- Las actualizaciones automáticas se gestionan con **Dependabot** (`.github/dependabot.yml`) — PRs revisados por humanos antes del merge.
+- Las vulnerabilidades críticas en dependencias se atienden con la misma prioridad que las del propio código.
+
+## Prácticas de Desarrollo Seguro
+
+### Autenticación y Autorización
+
+- Hashea contraseñas con un algoritmo robusto (bcrypt, argon2…).
+- Rota los tokens de sesión en cada login.
+- Valida la autorización **en el servidor** en cada request — nunca confíes en checks de cliente.
+- Valida server-side los flujos de OAuth/SSO.
+
+### Validación de Input
+
+- Valida y normaliza el input en todos los bordes del sistema.
+- Usa **queries parametrizadas** — nunca concatenes SQL.
+- Codifica el output según el contexto (HTML, atributo, URL, JS, CSS).
+- Prefiere listas blancas sobre listas negras.
+
+### Comunicación
+
+- HTTPS obligatorio en todos los entornos públicos (HSTS habilitado).
+- Cookies sensibles con `Secure`, `HttpOnly` y `SameSite`.
+- Verifica la firma de los webhooks entrantes sobre el cuerpo crudo.
+
+### Logging y Monitoreo
+
+- No loguees secretos, contraseñas, tokens ni PII innecesaria.
+- Centraliza los logs con retención y acceso controlado.
+- Monitorea errores y configura alertas para anomalías de autenticación y picos de error.
+
+### Backups y Recuperación
+
+- Backups automáticos y periódicos de los datos.
+- Backups cifrados y almacenados en una ubicación separada de producción.
+- Pruebas de restore periódicas — un backup sin restore probado no es un backup.
+
+### Code Review
+
+- Toda PR requiere aprobación antes del merge (ver [CONTRIBUTING.md](CONTRIBUTING.md)).
+- Los cambios sensibles (auth, criptografía, manejo de secretos, infraestructura) requieren revisión específica de seguridad.
+- El análisis estático y la auditoría de dependencias son checks bloqueantes.
+
+## Respuesta a Incidentes
+
+En caso de incidente de seguridad confirmado:
+
+1. **Contener**: aislar el sistema afectado, revocar credenciales comprometidas.
+2. **Comunicar internamente**: notificar al equipo responsable por el canal definido.
+3. **Investigar**: identificar causa raíz, alcance y vectores de explotación.
+4. **Remediar**: aplicar la corrección, redeploy, rotar todos los secretos potencialmente expuestos.
+5. **Notificar a los afectados**: si hubo exposición de datos personales, según las obligaciones legales aplicables.
+6. **Post-mortem**: documentar el incidente, lecciones aprendidas y acciones correctivas.
+
+## Reconocimientos
+
+Agradecemos a quienes reportan vulnerabilidades de forma responsable.
+
+<!-- Orden cronológico inverso. Formato: - YYYY-MM-DD — Nombre/Handle — Resumen breve -->
+
+- _Aún no hay reportes públicos._
+
+## Contacto
+
+- **Reportes de seguridad**: <brayandiazc@gmail.com> (asunto: `Security: …`)
+- **Consultas generales**: <brayandiazc@gmail.com>
+
+---
+
+> Versión: 1.0 — Última actualización: 2026-07-02

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Documentación de TechWorld Learning Platform
+
+Mapa de la documentación del proyecto. Empieza por aquí para saber qué documento
+responde cada pregunta.
+
+| Documento                                                      | Pregunta que responde                | Cuándo leerlo                   |
+| -------------------------------------------------------------- | ------------------------------------ | ------------------------------- |
+| [`architecture/architecture.md`](architecture/architecture.md) | ¿Cómo está construido el sistema?    | Al entender el panorama general |
+| [`architecture/stack.md`](architecture/stack.md)               | ¿Con qué tecnologías y versiones?    | Al configurar el entorno        |
+| [`architecture/database.md`](architecture/database.md)         | ¿Qué entidades y relaciones hay?     | Al trabajar con datos           |
+| [`architecture/auth.md`](architecture/auth.md)                 | ¿Cómo se entra y qué se permite?     | Al tocar autenticación/permisos |
+| [`architecture/api.md`](architecture/api.md)                   | ¿Qué endpoints expone?               | Al integrar o consumir la API   |
+| [`architecture/design.md`](architecture/design.md)             | ¿Cómo se ve y por qué?               | Al diseñar features o UI        |
+| [`product/business-model.md`](product/business-model.md)       | ¿Por qué existe / cómo genera valor? | Para entender el negocio        |
+| [`product/roadmap.md`](product/roadmap.md)                     | ¿Hacia dónde va?                     | Para conocer prioridades        |
+| [`decisions/`](decisions/README.md)                            | ¿Por qué tomamos cada decisión?      | Antes de re-debatir algo        |
+| [`conventions/`](conventions/README.md)                        | ¿Cómo trabajamos en este repo?       | Antes de escribir código        |
+| [`glossary.md`](glossary.md)                                   | ¿Qué significa cada término?         | Ante vocabulario desconocido    |
+
+## Sobre la distinción `architecture/` vs `conventions/`
+
+- **`architecture/`** describe **este** proyecto en concreto (su modelo de datos, su
+  auth, su API).
+- **`conventions/`** describe **reglas reusables** de cómo trabajamos
+  (cómo modelamos datos, cómo autenticamos, cómo testeamos) — transversales a
+  cualquier feature.
+
+## Cómo mantener esta documentación
+
+- Actualiza la línea **"Última actualización"** al editar un documento.
+- Registra las decisiones relevantes como [ADRs](decisions/README.md).
+- Mantén este índice al día si agregas o quitas documentos.

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -1,0 +1,143 @@
+# Referencia de rutas HTTP (vistas server-rendered)
+
+> Contrato de rutas HTTP de **TechWorld Learning Platform**.
+> Documentación interactiva: **No aplica en la versión actual** (no hay OpenAPI/Swagger/Postman).
+>
+> **Última actualización**: 2026-07-02
+
+## ¿API REST? No en esta versión
+
+TechWorld Learning Platform **no expone una API REST ni devuelve JSON**. Es una aplicación
+**server-rendered** construida con el patrón **MTV** (Modelo–Template–Vista) de Django: cada
+ruta ejecuta una vista que renderiza una plantilla HTML o realiza un `redirect`.
+
+Este documento describe, por tanto, el **contrato de las vistas HTTP** (rutas, métodos y
+comportamiento) en lugar de endpoints de una API JSON. La exposición de una API REST/JSON
+pública se contempla únicamente como **evolución futura** (ver [Posible evolución futura](#posible-evolución-futura)).
+
+## Convenciones generales
+
+- **URL base (desarrollo)**: `http://127.0.0.1:8000`
+- **Versionado**: No aplica en la versión actual (no hay prefijo de versión en las rutas).
+- **Formato**: HTML renderizado con Django Templates. **No** se responde `application/json`.
+- **Enrutamiento**: `techworld/urls.py` (ROOT_URLCONF) incluye `courses.urls` bajo `/courses/`
+  y `users.urls` bajo `/users/`, además del panel de administración en `/admin/`.
+- **Datos de formularios**: se envían como `application/x-www-form-urlencoded` (formularios HTML
+  clásicos) y se leen desde `request.POST` en las vistas.
+
+## Autenticación de las rutas
+
+- **No aplica un esquema de API.** No hay Bearer token ni API key.
+- El acceso a las vistas de `courses/` y `users/` **no está protegido** por autenticación en la
+  versión actual (ver [`auth.md`](auth.md)).
+- El único acceso autenticado es el panel `/admin/`, que usa el login nativo de Django.
+
+## Manejo de errores
+
+No hay un formato de error JSON estándar. El manejo de errores es el propio de una app HTML:
+
+- Errores de validación de negocio se comunican **re-renderizando la plantilla** con una variable
+  de contexto `error` (p. ej. login con "Contraseña incorrecta", inscripción con "Ya estás inscrito
+  en este curso.").
+- Recursos inexistentes: `enroll_course` usa `get_object_or_404(Course, id=course_id)`, que
+  devuelve una página **404** estándar de Django si el curso no existe.
+- Errores no controlados devuelven las páginas de error por defecto de Django (500 en producción,
+  traza de depuración si `DEBUG=True`).
+
+| Código HTTP | Cuándo ocurre en esta app                                              |
+| ----------- | --------------------------------------------------------------------- |
+| 200         | Renderizado normal de una plantilla (GET o POST que re-renderiza).    |
+| 302         | Redirecciones tras POST (`redirect` a `login`, `course_list`, etc.).  |
+| 404         | Curso inexistente en `enroll_course` (`get_object_or_404`).           |
+| 500         | Error interno no controlado.                                          |
+
+> No se emiten 401/403/422/429: no hay autenticación de API, validación estructurada ni rate limiting.
+
+## Paginación, filtrado y ordenamiento
+
+- **No aplica en la versión actual.** El listado de cursos (`course_list`) devuelve
+  `Course.objects.all()` sin paginación ni filtros. El orden de los cursos viene dado por el
+  `Meta.ordering = ["-created_at"]` del modelo `Course` (más recientes primero).
+
+## Rutas (contrato de vistas HTTP)
+
+### Administración
+
+```http
+GET/POST  /admin/            # Panel de administración de Django (auth nativa)
+```
+
+### Usuarios (`users/urls.py`, prefijo `/users/`)
+
+```http
+GET   /users/register/       # Muestra el formulario de registro (users/register.html)
+POST  /users/register/       # Crea el usuario (hash con make_password) y redirige a login
+GET   /users/login/          # Muestra el formulario de login (users/login.html)
+POST  /users/login/          # Valida credenciales con check_password
+```
+
+**`POST /users/register/`** — vista `register`
+
+- Campos del formulario: `username`, `email`, `password`, `first_name`, `last_name`,
+  `date_of_birth` (opcional), `city` (opcional), `role` (opcional, por defecto `student`).
+- Comportamiento: hashea la contraseña con `make_password`, crea el `users.User` y responde con
+  `redirect("login")` (302).
+
+**`POST /users/login/`** — vista `login_view`
+
+- Campos del formulario: `username`, `password`.
+- Comportamiento: busca el usuario por `username`; si `check_password` es correcto responde
+  `redirect("home")` (302); si no, re-renderiza `users/login.html` (200) con el mensaje de error.
+- **No** crea sesión de usuario (ver [`auth.md`](auth.md)). La ruta con nombre `home` no está
+  definida en la versión actual.
+
+### Cursos (`courses/urls.py`, prefijo `/courses/`)
+
+```http
+GET   /courses/                        # Lista todos los cursos (courses/course_list.html)
+GET   /courses/create/                 # Muestra el formulario de creación (create_course.html)
+POST  /courses/create/                 # Crea un curso y redirige al listado
+POST  /courses/<int:course_id>/enroll/ # Inscribe al request.user en el curso
+```
+
+**`GET /courses/`** — vista `course_list`
+
+- Comportamiento: renderiza `courses/course_list.html` con `Course.objects.all()` en el contexto.
+
+**`POST /courses/create/`** — vista `create_course`
+
+- Campos del formulario: `title`, `description`, `duration` (horas).
+- Comportamiento: crea el `Course` y responde `redirect("course_list")` (302). Un `GET` muestra
+  el formulario. **No** asigna instructor al curso.
+
+**`POST /courses/<int:course_id>/enroll/`** — vista `enroll_course`
+
+- Comportamiento: obtiene el curso con `get_object_or_404` (404 si no existe); si el par
+  `(request.user, course)` ya tiene una `Inscription`, re-renderiza `course_list.html` (200) con
+  `error = "Ya estás inscrito en este curso."`; en caso contrario crea la `Inscription` y responde
+  `redirect("course_list")` (302).
+- La restricción `unique_together = (user, course)` del modelo impide inscripciones duplicadas a
+  nivel de base de datos.
+- **Limitación conocida**: usa `request.user`, que no coincide con el modelo propio `users.User`
+  porque el login no autentica sesiones (ver deuda técnica en [`auth.md`](auth.md)).
+
+## Rate limiting
+
+- **No aplica en la versión actual.** No hay límites de tasa ni headers `X-RateLimit-*`.
+
+## Webhooks
+
+- **No aplica en la versión actual.** No se reciben ni emiten webhooks.
+
+## Posible evolución futura
+
+Exponer una API REST/JSON (por ejemplo con **Django REST Framework**) es una evolución posible pero
+**fuera del alcance de la versión 1.0.0**. Si se aborda, convendría:
+
+- Definir un prefijo de versión (`/api/v1/`) y respuestas JSON con `Content-Type: application/json`.
+- Reutilizar los modelos existentes (`User`, `Course`, `Inscription`) mediante serializadores.
+- Resolver antes la autenticación (ver [`auth.md`](auth.md)) para poder aplicar tokens y permisos.
+
+## Changelog
+
+- **1.0.0 (2026-07-02)**: primera versión documentada. App server-rendered (MTV) sin API JSON.

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -1,0 +1,105 @@
+# TechWorld Learning Platform — Arquitectura
+
+> Vista de alto nivel de cómo está construido el sistema y cómo se reparten las
+> responsabilidades. Para el stack real (versiones, librerías) ver
+> [`stack.md`](stack.md). Para el negocio ver
+> [`../product/business-model.md`](../product/business-model.md).
+>
+> **Última actualización**: 2026-07-02
+
+## Diagrama
+
+```mermaid
+graph TD
+    subgraph Cliente
+        A[Navegador web]
+    end
+    subgraph "Proyecto Django (techworld)"
+        B[techworld/urls.py<br/>ROOT_URLCONF]
+        C[App users<br/>urls / views / templates]
+        D[App courses<br/>urls / views / templates]
+        E[Django ORM<br/>Modelos User, Course, Inscription]
+        F[Django Admin]
+    end
+    subgraph Datos
+        G[(PostgreSQL)]
+    end
+
+    A --> B
+    B --> C
+    B --> D
+    B --> F
+    C --> E
+    D --> E
+    F --> E
+    E --> G
+```
+
+## Componentes
+
+| Componente              | Responsabilidad                                                                 | Tecnología           |
+| ----------------------- | ------------------------------------------------------------------------------- | -------------------- |
+| Proyecto `techworld`    | Configuración global (`settings.py`), enrutamiento raíz (`ROOT_URLCONF=techworld.urls`), WSGI/ASGI. | Django 5.1.3         |
+| App `users`             | Registro y login de usuarios; modelo propio `User` (tabla `users`).             | Django (MTV)         |
+| App `courses`           | Listado y creación de cursos e inscripción de usuarios (`Course`, `Inscription`). | Django (MTV)         |
+| Capa de datos (ORM)     | Mapeo de modelos a tablas y acceso a la base de datos.                           | Django ORM + PostgreSQL |
+| Django Admin            | Gestión administrativa de los modelos vía `/admin/`.                            | Django Admin         |
+
+## Decisiones clave
+
+| Decisión                                          | Razón                                                                                     |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Patrón MTV (Modelo-Template-Vista) con renderizado en servidor | Simplicidad y enfoque educativo; enseña el flujo completo de Django sin frontend separado. |
+| Modelo `User` propio (no extiende `AbstractUser`) | Ejercicio didáctico de modelado; login manual comparando hashes de contraseña.            |
+| Tabla intermedia `Inscription` con `progress`     | Modela la relación N:M entre usuarios y cursos añadiendo el progreso de cada inscripción. |
+| PostgreSQL como base de datos                     | Acerca el proyecto a un entorno de producción real.                                       |
+
+> El detalle y las alternativas de cada decisión relevante se registran como
+> ADRs en [`../decisions/`](../decisions/README.md).
+
+## Reglas no negociables
+
+- Un usuario no puede inscribirse dos veces en el mismo curso (`unique_together = (user, course)` en `Inscription`).
+- Las contraseñas nunca se almacenan en texto plano: se hashean con `make_password` al registrar y se verifican con `check_password` al iniciar sesión.
+- Todo acceso a datos pasa por el Django ORM; no hay SQL crudo en las vistas.
+
+## Flujos principales
+
+Flujo general de una petición (patrón MTV):
+
+```mermaid
+sequenceDiagram
+    actor U as Usuario (navegador)
+    participant R as techworld/urls.py
+    participant V as Vista (users/courses)
+    participant M as Modelo / ORM
+    participant D as PostgreSQL
+    participant T as Template
+    U->>R: HTTP request
+    R->>V: enruta a la vista
+    V->>M: consulta / guarda datos
+    M->>D: SQL vía ORM
+    D-->>M: filas
+    M-->>V: objetos
+    V->>T: contexto
+    T-->>U: HTML renderizado
+```
+
+Rutas principales:
+
+- `/admin/` — Django Admin.
+- `/users/register/` — `register` (POST crea usuario, hashea contraseña, redirige a login).
+- `/users/login/` — `login_view` (POST verifica `username` + `check_password`, redirige a `home`).
+- `/courses/` — `course_list` (lista todos los cursos).
+- `/courses/create/` — `create_course` (POST crea curso).
+- `/courses/<int:course_id>/enroll/` — `enroll_course` (POST inscribe al usuario, valida que no exista inscripción duplicada).
+
+> **Deuda técnica conocida (autenticación):** el login es manual y no usa el sistema de sesiones de `django.contrib.auth`, por lo que no hay sesión persistente real. En `enroll_course`, `request.user` depende del middleware de auth de Django, lo que puede ser inconsistente porque el modelo `User` es propio y no el de Django. Mejora prevista: migrar a `AbstractUser` o al sistema de autenticación de Django.
+
+## Referencias
+
+- [`stack.md`](stack.md) — stack tecnológico y versiones.
+- [`database.md`](database.md) — modelo de datos.
+- [`auth.md`](auth.md) — autenticación y autorización.
+- [`api.md`](api.md) — contrato de API.
+- [`../conventions/`](../conventions/README.md) — convenciones de trabajo.

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -1,0 +1,115 @@
+# Autenticación y Autorización
+
+> Cómo se autentican y autorizan los usuarios en **TechWorld Learning Platform**.
+> Para las reglas transversales ver [`../conventions/authentication.md`](../conventions/authentication.md).
+>
+> **Última actualización**: 2026-07-02
+
+## Visión general
+
+- **Método de autenticación**: implementación **manual** sobre el modelo propio `users.User`. No se usa `django.contrib.auth` para iniciar sesión: el login compara contraseñas a mano y **no crea una sesión persistente**.
+- **Almacenamiento de credenciales**: en la tabla `users` de PostgreSQL. El campo `password` es un `CharField(128)` que guarda el hash generado por Django.
+- **Hashing de contraseñas**: `django.contrib.auth.hashers.make_password` para hashear al registrar y `check_password` para verificar al iniciar sesión. Por defecto Django usa PBKDF2 (SHA256), por lo que ese es el algoritmo efectivo aunque no se configura explícitamente.
+
+> **Aviso de honestidad técnica**: la versión actual (1.0.0) es un MVP educativo. El flujo de login valida credenciales pero **no autentica realmente una sesión de Django**. Ver [Deuda técnica y mejoras futuras](#deuda-técnica-y-mejoras-futuras).
+
+## Modelo de identidad
+
+| Concepto       | Descripción                                                                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Usuario        | Modelo propio `users.User` (tabla `users`). **No extiende `AbstractUser`**; es un `models.Model` normal. Campos clave: `username` (único), `email` (único), `password` (hash), `first_name`, `last_name`, `role`, `date_of_birth`, `city`, `created_at`. |
+| Sesión / Token | **No aplica en la versión actual.** El login no genera sesión ni token; simplemente redirige tras validar la contraseña. No se emplea el framework de sesiones de Django para autenticar. |
+| Roles          | Campo `role` con opciones `student` (Estudiante, valor por defecto) e `instructor` (Instructor). Hoy es puramente informativo: no se usa para restringir accesos. |
+
+## Flujo de registro / login
+
+### Registro (`POST /users/register/`)
+
+```mermaid
+sequenceDiagram
+    actor U as Usuario
+    participant A as App (register)
+    participant DB as PostgreSQL
+    U->>A: Formulario (username, email, password, ...)
+    A->>A: make_password(password)  → hash
+    A->>DB: User.objects.create(...)
+    DB-->>A: Usuario creado
+    A-->>U: redirect("login")
+```
+
+- La vista `users.views.register` toma los campos del `request.POST`, hashea la contraseña con `make_password` y crea el registro con `User.objects.create(...)`.
+- Tras crear el usuario redirige a la vista `login`.
+- No hay verificación de email ni validación de fortaleza de contraseña.
+
+### Login (`POST /users/login/`)
+
+```mermaid
+sequenceDiagram
+    actor U as Usuario
+    participant A as App (login_view)
+    participant DB as PostgreSQL
+    U->>A: username + password
+    A->>DB: User.objects.get(username=...)
+    DB-->>A: Usuario (o DoesNotExist)
+    A->>A: check_password(password, user.password)
+    alt Contraseña válida
+        A-->>U: redirect("home")
+    else Contraseña inválida / usuario no existe
+        A-->>U: render login.html con mensaje de error
+    end
+```
+
+- La vista `users.views.login_view` busca el usuario por `username` y valida con `check_password`.
+- Si es correcto, hace `redirect("home")`. **Nota**: en la versión actual no existe una ruta con nombre `home` definida en las `urls`, por lo que este redirect quedaría sin destino resuelto; es un punto pendiente de la implementación.
+- Si falla, vuelve a renderizar `users/login.html` con `"Usuario no encontrado"` o `"Contraseña incorrecta"`.
+- **No se establece ninguna sesión**: no se llama a `django.contrib.auth.login()` ni se guarda estado del usuario autenticado.
+
+## Gestión de sesiones / tokens
+
+- **Expiración**: No aplica en la versión actual (no hay sesión de autenticación propia).
+- **Renovación**: No aplica en la versión actual.
+- **Revocación**: No aplica en la versión actual.
+
+> Django trae `SessionMiddleware` y `AuthenticationMiddleware` habilitados por defecto, pero el código de login **no** los utiliza para marcar al usuario como autenticado. Cualquier sesión de Django existente correspondería al usuario anónimo o al del panel `/admin/`.
+
+## Autorización
+
+- **Modelo**: No hay un modelo de autorización efectivo en la versión actual. El campo `role` existe en el modelo pero no se comprueba en ninguna vista.
+- **Dónde se valida**: no se realizan comprobaciones de permisos en las vistas de `users/` ni `courses/`. Cualquier visitante puede acceder a listar cursos, crear cursos e intentar inscribirse.
+- **Roles y permisos**:
+
+| Rol          | Permisos                                                                                     |
+| ------------ | -------------------------------------------------------------------------------------------- |
+| `student`    | Rol por defecto. Semánticamente representa a quien se inscribe en cursos. Hoy sin aplicación real de permisos. |
+| `instructor` | Semánticamente representa a quien crea cursos. Hoy `create_course` **no** exige este rol ni asigna instructor al curso. |
+
+## Proveedores externos (OAuth / SSO)
+
+- **No aplica en la versión actual.** No hay integración con proveedores externos de identidad.
+
+## Recuperación de cuenta
+
+- **No aplica en la versión actual.** No existe flujo de reset de contraseña, cambio de email ni verificación de cuenta.
+
+## Consideraciones de seguridad
+
+- Las contraseñas se almacenan **hasheadas** (nunca en texto plano) gracias a `make_password`.
+- El panel `/admin/` sí usa el sistema de autenticación nativo de Django y sus superusuarios.
+- La `SECRET_KEY` y las credenciales de base de datos se leen desde variables de entorno (`.env` vía `python-dotenv`).
+
+Ver [SECURITY.md](../../SECURITY.md) para la política completa.
+
+## Deuda técnica y mejoras futuras
+
+El diseño de autenticación actual es funcional para un MVP educativo, pero tiene limitaciones importantes que se documentan de forma explícita:
+
+1. **El login no crea sesión persistente.** `login_view` valida la contraseña y redirige, pero no llama a `django.contrib.auth.login()` ni guarda al usuario en la sesión. En la práctica, no queda ningún estado de "usuario autenticado".
+2. **`request.user` es inconsistente con el modelo propio.** En `courses.views.enroll_course` se usa `user = request.user` para crear la `Inscription`. Como el login no autentica en el sistema de Django, `request.user` corresponde al modelo `django.contrib.auth.models.User` (o a `AnonymousUser`), que **no es** el modelo propio `users.User` al que apunta la FK de `Inscription`. Esto provoca una inconsistencia entre el usuario "logueado" y el usuario que se intenta inscribir.
+3. **El modelo `users.User` no extiende `AbstractUser`** ni está declarado como `AUTH_USER_MODEL`, lo que impide reutilizar el ecosistema de auth de Django (decoradores `@login_required`, permisos, mixins, etc.).
+
+**Mejora recomendada**: migrar la autenticación al sistema nativo de Django. Dos caminos posibles:
+
+- Hacer que `users.User` extienda `AbstractUser` (o `AbstractBaseUser`) y configurarlo como `AUTH_USER_MODEL`, reemplazando el login manual por `authenticate()` + `login()` y protegiendo vistas con `@login_required`.
+- O bien adoptar el modelo `User` nativo de Django y trasladar los campos extra (`role`, `date_of_birth`, `city`) a un perfil relacionado.
+
+Cualquiera de las dos opciones resolvería la inconsistencia de `request.user`, habilitaría sesiones reales y permitiría implementar autorización por rol de forma robusta.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -1,0 +1,100 @@
+# Modelo de Datos
+
+> Esquema, entidades y relaciones de **TechWorld Learning Platform**.
+> Para las **reglas y estándares** de modelado (nomenclatura, tipos, índices)
+> ver [`../conventions/database.md`](../conventions/database.md).
+>
+> **Última actualización**: 2026-07-02
+
+## Diagrama Entidad-Relación
+
+```mermaid
+erDiagram
+    USER ||--o{ INSCRIPTION : "se inscribe"
+    COURSE ||--o{ INSCRIPTION : "tiene inscritos"
+    USER {
+        int id PK
+        string username "unique, 50"
+        string email "unique"
+        string password "hash, 128"
+        string first_name "50"
+        string last_name "50"
+        string role "student | instructor"
+        date date_of_birth "null, blank"
+        string city "null, blank, 50"
+        datetime created_at "auto_now_add"
+    }
+    COURSE {
+        int id PK
+        string title "200"
+        text description
+        int duration "horas, positivo"
+        datetime created_at "auto_now_add"
+    }
+    INSCRIPTION {
+        int id PK
+        int user_id FK
+        int course_id FK
+        int progress "porcentaje, default 0"
+        datetime enrolled_at "auto_now_add"
+    }
+```
+
+## Entidades principales
+
+### User (app `users`, tabla `users`)
+
+- **Propósito**: Representa a las personas de la plataforma (estudiantes e instructores). Es un modelo propio; **no** extiende `AbstractUser`.
+- **Campos clave**:
+  - `username` (CharField 50, `unique`) — identificador de acceso.
+  - `email` (EmailField, `unique`).
+  - `password` (CharField 128) — se almacena hasheado con `django.contrib.auth.hashers.make_password`.
+  - `first_name`, `last_name` (CharField 50).
+  - `role` (CharField 10, `choices=[("student","Estudiante"),("instructor","Instructor")]`, `default="student"`).
+  - `date_of_birth` (DateField, `null`, `blank`).
+  - `city` (CharField 50, `null`, `blank`).
+  - `created_at` (DateTimeField, `auto_now_add`).
+- **Relaciones**: 1:N con `Inscription` (un usuario puede tener muchas inscripciones).
+
+### Course (app `courses`, verbose "Curso")
+
+- **Propósito**: Representa un curso disponible en la plataforma.
+- **Campos clave**:
+  - `title` (CharField 200).
+  - `description` (TextField).
+  - `duration` (PositiveIntegerField) — duración en horas.
+  - `created_at` (DateTimeField, `auto_now_add`); `ordering = ["-created_at"]`.
+- **Relaciones**: 1:N con `Inscription` (un curso puede tener muchos inscritos). En la versión actual el modelo no asigna un instructor mediante FK.
+
+### Inscription (app `courses`, verbose "Inscripción")
+
+- **Propósito**: Tabla intermedia que modela la relación N:M entre `User` y `Course`, guardando además el progreso.
+- **Campos clave**:
+  - `user` (FK a `users.User`, `on_delete=CASCADE`).
+  - `course` (FK a `Course`, `on_delete=CASCADE`).
+  - `progress` (PositiveIntegerField, `default=0`) — porcentaje de avance.
+  - `enrolled_at` (DateTimeField, `auto_now_add`).
+- **Relaciones**: N:1 con `User` y N:1 con `Course`. Restricción `unique_together = (user, course)`.
+
+## Relaciones y cardinalidad
+
+| Relación                | Cardinalidad | Notas                                                        |
+| ----------------------- | ------------ | ------------------------------------------------------------ |
+| User → Inscription      | 1:N          | Borrado en cascada (`on_delete=CASCADE`).                    |
+| Course → Inscription    | 1:N          | Borrado en cascada (`on_delete=CASCADE`).                    |
+| User ↔ Course           | N:M          | Materializada a través de `Inscription` (con `progress`).    |
+
+## Índices y restricciones
+
+- `User.username` y `User.email`: restricción de unicidad (`unique`), evitan usuarios duplicados.
+- `Inscription`: `unique_together = (user, course)`, impide que un usuario se inscriba dos veces en el mismo curso.
+- Claves foráneas de `Inscription` (`user`, `course`) con `on_delete=CASCADE`: al eliminar un usuario o un curso se eliminan sus inscripciones.
+
+## Migraciones y versionado del esquema
+
+- Las migraciones se generan con `python manage.py makemigrations` y se aplican con `python manage.py migrate`.
+- Al ser un MVP educativo, se mantiene el historial de migraciones de Django como fuente de versionado del esquema.
+
+## Datos semilla (seeds)
+
+- Los datos iniciales se cargan mediante fixtures JSON con `python manage.py loaddata`.

--- a/docs/architecture/design.md
+++ b/docs/architecture/design.md
@@ -1,0 +1,131 @@
+# Diseño — TechWorld Learning Platform
+
+> Decisiones de diseño técnico y de producto: cómo se resuelve el problema y
+> cómo se ve y se siente el producto. Las decisiones relevantes se promueven a
+> ADRs en [`../decisions/`](../decisions/README.md).
+>
+> **Última actualización**: 2026-07-02
+
+## Contexto y objetivos
+
+- **Problema**: los estudiantes de Inforcap necesitan un proyecto de referencia, sencillo y
+  realista, para aprender a construir una aplicación web con Django siguiendo el patrón MTV. La
+  plataforma modela un caso de uso reconocible: gestión de cursos e inscripciones.
+- **Objetivos**: permitir registrar usuarios, listar cursos, crear cursos e inscribirse en ellos;
+  mantener el código legible y didáctico; usar tecnologías estándar de Django sin capas de
+  complejidad innecesarias.
+- **No-objetivos**: no se busca una plataforma de producción. Quedan explícitamente fuera: API REST,
+  SPA/JS framework, tests automatizados, CI/CD, despliegue, internacionalización, cache, colas,
+  emails y un sistema de autenticación robusto (ver [`auth.md`](auth.md)).
+
+## Requisitos
+
+### Funcionales
+
+- Registro de usuarios con contraseña hasheada (`make_password`).
+- Inicio de sesión validando credenciales (`check_password`).
+- Listado de todos los cursos disponibles.
+- Creación de cursos (título, descripción, duración).
+- Inscripción de un usuario en un curso, sin permitir duplicados (`unique_together`).
+- Distinción semántica de roles `student` / `instructor` en el modelo de usuario.
+
+### No funcionales
+
+- **Simplicidad y legibilidad**: prioridad didáctica; código directo con vistas basadas en funciones.
+- **Portabilidad de configuración**: parámetros sensibles (`SECRET_KEY`, credenciales de BD, `DEBUG`)
+  vía variables de entorno con `python-dotenv`.
+- **Seguridad básica**: contraseñas siempre hasheadas, nunca en texto plano.
+- **Rendimiento/escalabilidad/accesibilidad**: no son objetivos de este MVP; se cubren solo por lo
+  que aporta Bootstrap por defecto.
+
+## Diseño propuesto
+
+- **Enfoque general**: aplicación Django server-rendered con patrón **MTV**. Dos apps de dominio
+  (`users`, `courses`) más el proyecto `techworld`. PostgreSQL como base de datos vía Django ORM.
+  Las vistas son funciones simples que leen `request.POST` y renderizan plantillas o redirigen.
+- **Componentes y flujos**:
+  - `techworld/` — configuración, `urls` raíz (incluye `users/` y `courses/`), WSGI/ASGI.
+  - `users/` — modelo `User` propio, vistas `register` y `login_view`, plantillas de auth.
+  - `courses/` — modelos `Course` e `Inscription`, vistas `course_list`, `create_course` y
+    `enroll_course`, plantillas de cursos.
+  - Detalle de piezas y relaciones en [`architecture.md`](architecture.md); modelo de datos en
+    [`database.md`](database.md).
+
+## Alternativas consideradas
+
+| Alternativa                                | Pros                                      | Contras                                                        | ¿Por qué se descartó?                                              |
+| ------------------------------------------ | ----------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------ |
+| SPA (React/Vue) + API REST (DRF)           | Frontend rico, separación clara           | Mayor complejidad, dos stacks, más difícil de enseñar          | El objetivo es enseñar el patrón MTV de Django de forma sencilla.  |
+| Auth nativo de Django (`AbstractUser`)     | Sesiones reales, permisos, `@login_required` | Requiere entender más del framework desde el inicio            | Se pospuso para un MVP más simple; queda como deuda técnica.       |
+| Frontend con CSS propio sin framework      | Control total del estilo                  | Más tiempo en CSS, menos foco en backend                       | Bootstrap acelera una UI decente con esfuerzo mínimo.              |
+
+## Identidad visual y sistema de diseño
+
+- **Principios de diseño**: claridad y funcionalidad por encima de la estética; consistencia
+  mediante herencia de plantillas; UI mínima suficiente para un MVP educativo.
+- **Motor de plantillas**: Django Templates con **herencia**. `templates/base.html` define el
+  esqueleto HTML (bloques `title` y `content`) e **incluye** `templates/navbar.html` con
+  `{% include 'navbar.html' %}`. Las plantillas de cada app extienden esta base.
+- **Estilos**: **Bootstrap 5.3.3** cargado desde CDN (`cdn.jsdelivr.net`) en `base.html`, incluyendo
+  su JS bundle. Se usan clases utilitarias y componentes de Bootstrap (`navbar`, `container`,
+  `card`, `form-control`, etc.).
+- **Hoja de estilos propia**: existe `static/css/styles.css` con ajustes menores (fondo claro
+  `#f8f9fa`, márgenes de navbar/card/formularios). **Nota**: en la versión actual su `<link>` está
+  **comentado** en `base.html`, por lo que estos estilos no se están aplicando; queda pendiente
+  habilitarlo (requiere `{% load static %}`).
+- **Tokens**: no hay un sistema formal de tokens; los colores y espaciados provienen de Bootstrap y
+  de los pocos valores de `styles.css`.
+- **Componentes / primitivas permitidas**: los de Bootstrap 5. No hay librería de componentes propia.
+
+### Páginas / plantillas
+
+| Plantilla                              | Ruta                          | Propósito                                        |
+| -------------------------------------- | ----------------------------- | ------------------------------------------------ |
+| `templates/base.html`                  | —                             | Esqueleto base (Bootstrap + bloques + navbar).   |
+| `templates/navbar.html`                | —                             | Barra de navegación global (Cursos, Registrarse, Iniciar Sesión). |
+| `users/templates/users/register.html`  | `/users/register/`            | Formulario de registro.                          |
+| `users/templates/users/login.html`     | `/users/login/`               | Formulario de inicio de sesión.                  |
+| `courses/templates/courses/course_list.html` | `/courses/`             | Listado de cursos y botón de inscripción.        |
+| `courses/templates/courses/create_course.html` | `/courses/create/`    | Formulario de creación de curso.                 |
+
+## Accesibilidad
+
+- Se hereda lo que aporta Bootstrap por defecto (contraste y foco de sus componentes; `navbar` con
+  atributos ARIA en el toggler).
+- **No** hay un trabajo específico de accesibilidad (auditoría de contraste WCAG, gestión de foco
+  personalizada ni roles/atributos ARIA adicionales). Queda como mejora futura.
+
+## Estados de la interfaz
+
+- **Éxito**: creación de usuario/curso e inscripción redirigen a la vista correspondiente
+  (`login`, `course_list`).
+- **Error**: se comunica re-renderizando la plantilla con una variable `error` en el contexto
+  (login: "Usuario no encontrado" / "Contraseña incorrecta"; inscripción: "Ya estás inscrito en
+  este curso.").
+- **Vacío**: el listado de cursos depende de que existan registros; no hay un estado de "sin cursos"
+  diseñado explícitamente (mejora pendiente).
+- **Carga**: no aplica en la versión actual (renderizado síncrono en servidor, sin llamadas
+  asíncronas desde el cliente).
+
+## Modelo de datos afectado
+
+El diseño se apoya en tres entidades: `users.User`, `courses.Course` y `courses.Inscription`
+(tabla intermedia con `progress` y restricción `unique_together = (user, course)`). Ver el detalle
+en [`database.md`](database.md).
+
+## Riesgos y mitigaciones
+
+| Riesgo                                                             | Impacto | Mitigación                                                                 |
+| ----------------------------------------------------------------- | ------- | -------------------------------------------------------------------------- |
+| Login sin sesión real e inconsistencia de `request.user`          | Alto    | Migrar al auth nativo de Django (ver deuda técnica en [`auth.md`](auth.md)). |
+| Dependencia de CDN para Bootstrap (sin internet no hay estilos)   | Medio   | Servir Bootstrap localmente vía `static/` en una iteración futura.         |
+| `styles.css` no se carga (link comentado en `base.html`)          | Bajo    | Habilitar el `<link>` con `{% load static %}` cuando se necesite.          |
+| Ausencia de tests y validación de formularios                     | Medio   | Añadir Django Forms y una suite de tests como mejora planificada.          |
+
+## Preguntas abiertas
+
+- [ ] ¿Se migrará la autenticación a `AbstractUser` / auth nativo de Django?
+- [ ] ¿Se habilitará `static/css/styles.css` o se consolidará todo en Bootstrap?
+- [ ] ¿Debe `create_course` asignar el instructor (usuario) que crea el curso?
+- [ ] ¿Se añadirá una vista de progreso y un panel de analítica (previstos en el README)?
+- [ ] ¿Se definirá una página de inicio para el `redirect("home")` del login?

--- a/docs/architecture/stack.md
+++ b/docs/architecture/stack.md
@@ -1,0 +1,72 @@
+# Stack Tecnológico
+
+> Fuente de verdad de las tecnologías y versiones del proyecto.
+> **Última actualización**: 2026-07-02
+
+## Frontend
+
+| Categoría | Tecnología                    | Versión | Por qué |
+| --------- | ----------------------------- | ------- | ------- |
+| Framework | Django Templates (renderizado en servidor, patrón MTV) | 5.1.3 | El proyecto no usa una SPA ni framework JS; las vistas devuelven HTML renderizado en el servidor. |
+| Estado    | No aplica en la versión actual | —      | Al ser renderizado en servidor, no hay una capa de estado en el cliente. |
+| Estilos   | Bootstrap + CSS propio (`static/css/styles.css`) | — | Bootstrap acelera el maquetado responsivo del MVP; el CSS propio ajusta detalles. |
+| Build     | No aplica en la versión actual | —      | No hay bundler; los estáticos se sirven directamente con el sistema de archivos estáticos de Django. |
+
+## Backend
+
+| Categoría           | Tecnología                         | Versión | Por qué |
+| ------------------- | ---------------------------------- | ------- | ------- |
+| Runtime             | Python                             | 3.10+   | Versión mínima requerida por Django 5.1.x. |
+| Framework           | Django                             | 5.1.3   | Framework backend full-stack que provee el patrón MTV, ORM, admin y enrutamiento. |
+| ORM / capa de datos | Django ORM                         | 5.1.3   | Incluido en Django; mapea los modelos (`User`, `Course`, `Inscription`) a tablas de PostgreSQL. |
+| Validación          | Validación integrada de modelos y formularios de Django | 5.1.3 | Se usan las restricciones y validaciones que ofrece el propio framework (campos, `unique`, `choices`). |
+
+## Base de Datos
+
+| Categoría | Tecnología                       | Versión | Por qué |
+| --------- | -------------------------------- | ------- | ------- |
+| Principal | PostgreSQL (motor `django.db.backends.postgresql` vía `psycopg2-binary`) | psycopg2-binary 2.9.10 | Base de datos relacional robusta y estándar en producción con Django. |
+| Cache     | No aplica en la versión actual   | —       | El MVP no configura una capa de cache. |
+| Cola      | No aplica en la versión actual   | —       | No hay procesamiento asíncrono ni tareas en segundo plano. |
+
+## DevOps & Herramientas
+
+| Categoría    | Tecnología                                    |
+| ------------ | --------------------------------------------- |
+| CI/CD        | No aplica en la versión actual                |
+| Contenedores | No aplica en la versión actual                |
+| Orquestación | No aplica en la versión actual                |
+| Monitoreo    | No aplica en la versión actual                |
+| Testing      | No aplica en la versión actual (los archivos `tests.py` están vacíos) |
+
+## Servicios externos
+
+| Servicio     | Uso              | Credenciales necesarias |
+| ------------ | ---------------- | ----------------------- |
+| No aplica en la versión actual | El proyecto no integra servicios externos de terceros. | — |
+
+> Configuración por variables de entorno (`.env`, leídas en `techworld/settings.py` con `python-dotenv==1.0.1`): `DB_HOST`, `DB_PORT` (5432), `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `SECRET_KEY`, `DEBUG`.
+
+## Justificación de elecciones
+
+| Tecnología elegida            | Alternativa descartada       | Razón                                                            |
+| ----------------------------- | ---------------------------- | ---------------------------------------------------------------- |
+| Django Templates (MTV)        | SPA (React/Vue) + API REST   | Es un proyecto educativo/MVP; el renderizado en servidor mantiene el foco en aprender Django sin complejidad de frontend. |
+| PostgreSQL                    | SQLite                       | Se prefiere una base de datos de nivel producción para acercar el ejercicio a un escenario real. |
+| pip + `requirements.txt`      | Poetry / Pipenv              | Gestor de paquetes estándar y suficiente para el alcance del MVP. |
+
+## Dependencias (requirements.txt)
+
+- `asgiref==3.8.1`
+- `Django==5.1.3`
+- `psycopg2-binary==2.9.10`
+- `python-dotenv==1.0.1`
+- `sqlparse==0.5.2`
+
+Instalación: `pip install -r requirements.txt`. Servidor de desarrollo: `python manage.py runserver` (http://127.0.0.1:8000). Datos iniciales: fixtures JSON cargados con `python manage.py loaddata`.
+
+## Versiones mínimas soportadas
+
+- Python >= 3.10
+- Django == 5.1.3
+- PostgreSQL con driver `psycopg2-binary` >= 2.9.10

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -1,0 +1,45 @@
+# Convenciones
+
+Esta carpeta documenta **cómo trabajamos** en TechWorld Learning Platform: reglas y
+estándares transversales que aplican al día a día, independientes de cualquier
+feature concreta.
+
+> Diferencia con `docs/architecture/`: aquí van las **reglas** ("cómo modelamos
+> datos"); en `architecture/` va **este** proyecto en concreto ("cuál es nuestro
+> modelo de datos").
+
+## Convenciones incluidas
+
+| Convención                                         | Tema                               |
+| -------------------------------------------------- | ---------------------------------- |
+| [authentication.md](authentication.md)             | Autenticación y autorización       |
+| [branding.md](branding.md)                         | Identidad de marca y assets        |
+| [database.md](database.md)                         | Modelado de datos y migraciones    |
+| [deploy.md](deploy.md)                             | Despliegue y operaciones           |
+| [design-system.md](design-system.md)               | Sistema de diseño y componentes    |
+| [i18n.md](i18n.md)                                 | Internacionalización               |
+| [quality-tooling.md](quality-tooling.md)           | Linters, formato y git hooks       |
+| [secrets.md](secrets.md)                           | Manejo de secretos y credenciales  |
+| [seo.md](seo.md)                                   | SEO y metadatos                    |
+| [testing.md](testing.md)                           | Estrategia y estándares de testing |
+| [transactional-emails.md](transactional-emails.md) | Correos transaccionales            |
+| [views-and-layouts.md](views-and-layouts.md)       | Vistas, layouts y UI compartida    |
+
+## Agregar una convención
+
+Copia [`_template.md`](_template.md), renómbralo en `kebab-case` y documenta el
+nuevo tema. Añádelo a la tabla de arriba.
+
+## Convenciones adicionales opcionales
+
+No se incluyen por defecto; créalas con `_template.md` si tu proyecto las necesita.
+
+- **Genéricas / SaaS**: pagos, webhooks, multi-tenancy, PWA, administración,
+  aceptación legal, observabilidad.
+- **Móvil**: release a stores (versionado, firma/code-signing, capturas y ASO),
+  permisos del dispositivo, notificaciones push, modo offline.
+- **Escritorio**: empaquetado e instaladores por SO, code signing y notarización,
+  auto-update, telemetría / reporte de crashes.
+
+> Ver [`TEMPLATE-USAGE.md`](../../TEMPLATE-USAGE.md) § "Adaptar por tipo de proyecto"
+> para qué borrar y qué reenfocar según sea web, móvil o escritorio.

--- a/docs/conventions/_template.md
+++ b/docs/conventions/_template.md
@@ -1,0 +1,33 @@
+# Convenciones de [TEMA]
+
+> Reglas y estándares de [TEMA] en TechWorld Learning Platform.
+> **Última actualización**: 2026-07-02
+
+## Stack
+
+- [Herramientas / librerías que cubre esta convención].
+
+## Estructura
+
+- [Carpetas y archivos relevantes para este tema].
+
+## Reglas
+
+- [Regla inviolable 1].
+- [Regla inviolable 2].
+
+## Ejemplos
+
+```text
+[Ejemplo de cómo hacerlo bien — reemplaza con código de tu stack]
+```
+
+## Comandos útiles
+
+```bash
+[COMANDO_RELEVANTE]
+```
+
+## Referencias
+
+- [Enlaces a documentación oficial o ADRs relacionados].

--- a/docs/conventions/authentication.md
+++ b/docs/conventions/authentication.md
@@ -1,0 +1,45 @@
+# Convenciones de autenticación y autorización
+
+> Reglas transversales de autenticación y autorización en TechWorld Learning Platform.
+> Para cómo funciona la auth en este proyecto ver
+> [`../architecture/auth.md`](../architecture/auth.md).
+> **Última actualización**: 2026-07-02
+
+## Stack
+
+- **Autenticación**: login manual (verificación de `username` + `check_password`). Deuda técnica: migrar al sistema de auth de Django.
+- **Autorización**: validación en las vistas de Django según el campo `role` del usuario.
+- **Hashing de contraseñas**: `make_password` / `check_password` de `django.contrib.auth.hashers`.
+
+## Reglas
+
+- La autorización se valida **siempre en el servidor**, en cada request.
+- Nunca confiar en checks de cliente para decisiones de seguridad.
+- Las contraseñas se almacenan hasheadas con un algoritmo robusto y salt.
+- Los tokens/sesiones se rotan en cada login y tienen expiración.
+- Los flujos OAuth/SSO se validan server-side (email y UID).
+
+## Modelo
+
+- **Usuario**: `users.User` con `username`, `email`, `password` (hasheado) y `role`.
+- **Sesión / token**: no hay sesión persistente real todavía; depende del middleware de auth de Django (deuda técnica).
+- **Roles / permisos**: RBAC simple por el campo `role` (`student` / `instructor`).
+
+## Ejemplos
+
+```text
+# Pseudocódigo de verificación de autorización
+if not current_user.can?(:accion, recurso)
+  rechazar(403)
+```
+
+## Comandos útiles
+
+```bash
+python manage.py createsuperuser   # crear usuario administrador del admin de Django
+```
+
+## Referencias
+
+- [`../architecture/auth.md`](../architecture/auth.md)
+- [SECURITY.md](../../SECURITY.md)

--- a/docs/conventions/branding.md
+++ b/docs/conventions/branding.md
@@ -1,0 +1,41 @@
+# Convenciones de marca (branding)
+
+> Identidad visual y gestión de assets de marca de TechWorld Learning Platform.
+> Para tokens y componentes de UI ver [`design-system.md`](design-system.md).
+> **Última actualización**: 2026-07-02
+
+## Logos
+
+| Asset             | Archivo fuente     | Uso                     |
+| ----------------- | ------------------ | ----------------------- |
+| Isotipo (símbolo) | `static/img/logo-mark.svg` | Favicon, app icon       |
+| Logotipo (texto)  | `static/img/logo.svg`      | Header, materiales      |
+| Versión monocroma | `static/img/logo-mono.svg` | Fondos de un solo color |
+
+- Mantén los fuentes en formato vectorial (SVG) y genera los rasterizados desde ahí.
+
+## Paleta y tipografía
+
+- Definidas como tokens en el [sistema de diseño](design-system.md).
+- **Colores de marca**: definidos por Bootstrap (sin personalización de marca en la versión actual).
+- **Tipografías**: familia por defecto de Bootstrap (`system-ui` / pila nativa del sistema).
+
+## Reglas de uso
+
+- Respeta el área de protección (espacio libre) alrededor del logo.
+- No deformes, recolores ni apliques efectos no autorizados al logo.
+- Usa la variante adecuada según el fondo (claro/oscuro/color).
+
+## Assets
+
+```text
+static/img/
+├── logo.svg
+├── logo-mark.svg
+└── og-image.png   # 1200×630 para compartir en redes
+```
+
+## Referencias
+
+- [`design-system.md`](design-system.md)
+- Guía de marca completa: No aplica en la versión actual.

--- a/docs/conventions/database.md
+++ b/docs/conventions/database.md
@@ -1,0 +1,57 @@
+# Convenciones de base de datos
+
+> Reglas y estándares de modelado de datos en TechWorld Learning Platform.
+> Para el modelo de datos concreto del proyecto ver
+> [`../architecture/database.md`](../architecture/database.md).
+> **Última actualización**: 2026-07-02
+
+## Stack
+
+- **Motor**: PostgreSQL.
+- **Capa de acceso / ORM**: Django ORM.
+- **Migraciones**: sistema de migraciones de Django (`python manage.py makemigrations` / `migrate`).
+
+## Reglas de modelado
+
+- **Primary keys**: autoincremental (`id` generado por Django) de forma consistente.
+- **Nombres**: tablas y columnas en snake_case, en inglés.
+- **Timestamps**: toda tabla tiene `created_at` y `updated_at`.
+- **Foreign keys**: siempre con índice; `NOT NULL` salvo justificación explícita.
+- **Tipos preferidos**:
+
+| Caso              | Tipo                     |
+| ----------------- | ------------------------ |
+| Email             | `EmailField`             |
+| Texto corto       | `CharField`              |
+| Texto largo       | `TextField`              |
+| JSON estructurado | `JSONField`              |
+| Dinero            | `DecimalField`           |
+| Booleano          | `BooleanField` con default |
+
+## Migraciones
+
+- Reversibles y no destructivas siempre que sea posible.
+- Una migración por cambio lógico; nunca editar una migración ya aplicada en `main`.
+- Revisar el impacto en datos existentes antes de aplicar en producción.
+
+## Ejemplos
+
+```python
+class Recurso(models.Model):
+    referencia = models.ForeignKey(Otro, on_delete=models.CASCADE)  # fk, indexada
+    nombre = models.CharField(max_length=200)                       # texto, not null
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+```
+
+## Comandos útiles
+
+```bash
+python manage.py makemigrations              # crear migración
+python manage.py migrate                      # aplicar migraciones
+python manage.py migrate <app> <migracion_anterior>   # rollback a una migración previa
+```
+
+## Referencias
+
+- Documentación de Django ORM y del motor PostgreSQL.

--- a/docs/conventions/deploy.md
+++ b/docs/conventions/deploy.md
@@ -1,0 +1,65 @@
+# Convenciones de despliegue
+
+> Operaciones de producción de TechWorld Learning Platform. Fuente de verdad de cómo se
+> despliega, se hace rollback y se opera el sistema.
+> **Última actualización**: 2026-07-02
+
+> **Estado**: no hay pipeline de despliegue configurado aún. Este documento describe el
+> esquema típico previsto (gunicorn + `collectstatic` + `migrate`) y queda pendiente de
+> definir en detalle.
+
+## Stack de infraestructura
+
+- **Hosting / cómputo**: pendiente de definir.
+- **DNS / TLS**: pendiente de definir.
+- **Contenedores / orquestación**: No aplica en la versión actual.
+- **CI/CD**: GitHub Actions (ver `.github/workflows/`, aún de ejemplo).
+
+## Ambientes
+
+| Ambiente   | URL              | Rama      | Deploy     |
+| ---------- | ---------------- | --------- | ---------- |
+| Desarrollo | http://127.0.0.1:8000 | `develop` | Automático |
+| Staging    | pendiente de definir  | `staging` | Automático |
+| Producción | pendiente de definir  | `main`    | Manual     |
+
+## Reglas
+
+- Solo se despliega a producción desde `main`.
+- Cada deploy debe ser reproducible y reversible.
+- Las variables de entorno y secretos se gestionan según [`secrets.md`](secrets.md).
+- Verificar health checks tras cada deploy.
+
+## Procedimiento de deploy
+
+```bash
+# Esquema típico previsto (pipeline pendiente de definir)
+
+# 1. Preparar estáticos
+python manage.py collectstatic --noinput
+
+# 2. Aplicar migraciones y servir con gunicorn
+python manage.py migrate
+gunicorn techworld.wsgi
+
+# 3. Verificar
+# Comando de deploy: pendiente de definir.
+```
+
+## Rollback
+
+```bash
+# Pendiente de definir (a nivel de infraestructura).
+# A nivel de datos, revertir migraciones:
+python manage.py migrate <app> <migracion_anterior>
+```
+
+## Health checks y monitoreo
+
+- Endpoint de salud: No aplica en la versión actual.
+- Monitoreo de errores: No aplica en la versión actual.
+- Alertas: No aplica en la versión actual.
+
+## Referencias
+
+- Documentación oficial de despliegue de Django (gunicorn, `collectstatic`, `migrate`).

--- a/docs/conventions/design-system.md
+++ b/docs/conventions/design-system.md
@@ -1,0 +1,43 @@
+# Convenciones del sistema de diseño
+
+> Tokens, componentes y reglas de UI de TechWorld Learning Platform.
+> Para el diseño técnico/UX del producto ver
+> [`../architecture/design.md`](../architecture/design.md).
+> **Última actualización**: 2026-07-02
+
+## Stack
+
+- **Librería de componentes**: Bootstrap.
+- **Solución de estilos**: Bootstrap + Django Templates (más `static/css/styles.css`).
+- **Página de referencia viva** (si aplica): No aplica en la versión actual.
+
+## Tokens
+
+| Token          | Uso                             |
+| -------------- | ------------------------------- |
+| Colores        | primario, secundario y estados de Bootstrap |
+| Tipografía     | familias y escalas de Bootstrap             |
+| Espaciado      | escala de espaciado de Bootstrap            |
+| Bordes/sombras | radios y elevaciones de Bootstrap           |
+
+> Usa **tokens semánticos** (p. ej. `color-primario`), no valores crudos, en los componentes.
+
+## Componentes permitidos
+
+- Usa los componentes de la librería; evita crear variantes ad-hoc.
+- Cada componente debe contemplar sus **estados**: normal, hover, foco, deshabilitado, carga, error.
+
+## Accesibilidad (baseline)
+
+- Contraste mínimo objetivo: WCAG AA.
+- Foco visible y navegación por teclado.
+- Roles/atributos ARIA donde corresponda.
+
+## Anti-patrones
+
+- Valores de color/espaciado hardcodeados fuera de los tokens.
+- Componentes duplicados que reimplementan algo existente.
+
+## Referencias
+
+- Documentación oficial de Bootstrap.

--- a/docs/conventions/quality-tooling.md
+++ b/docs/conventions/quality-tooling.md
@@ -1,0 +1,46 @@
+# Convenciones de calidad y tooling
+
+> Linters, formato, análisis estático y git hooks de TechWorld Learning Platform.
+> **Última actualización**: 2026-07-02
+
+## Stack
+
+- **Linter**: ruff (o flake8).
+- **Formateador**: black (longitud de línea 88).
+- **Análisis estático / seguridad**: No aplica en la versión actual.
+- **Auditoría de dependencias**: No aplica en la versión actual.
+- **Orquestador de git hooks**: pre-commit (opcional; No aplica en la versión actual).
+
+## Git hooks
+
+Estrategia sugerida: hooks baratos y rápidos en `pre-commit`, los más costosos en
+`pre-push`. CI ejecuta todo de nuevo en el servidor.
+
+### pre-commit (en cada commit)
+
+- Linter sobre archivos cambiados.
+- Formato automático.
+- Verificación de trailing whitespace, fin de archivo, conflictos sin resolver.
+
+### pre-push (al subir)
+
+- Linter completo.
+- Tests (o un subconjunto rápido).
+- Auditoría de dependencias.
+
+## Reglas
+
+- El código debe pasar linter y formato antes del merge.
+- Los checks de calidad son **bloqueantes** en CI.
+
+## Comandos útiles
+
+```bash
+ruff check .    # lint
+black .         # formato
+# Auditoría de dependencias: No aplica en la versión actual.
+```
+
+## Referencias
+
+- Documentación oficial de black y ruff.

--- a/docs/conventions/secrets.md
+++ b/docs/conventions/secrets.md
@@ -1,0 +1,45 @@
+# Convenciones de secretos y credenciales
+
+> Cómo gestionamos secretos en TechWorld Learning Platform.
+> **Última actualización**: 2026-07-02
+
+## Filosofía
+
+- Los secretos **nunca** se commitean en texto plano.
+- Separación clara entre **configuración** (no sensible) y **secretos** (sensible).
+
+## Dónde vive cada cosa
+
+| Tipo                         | Dónde                                         |
+| ---------------------------- | --------------------------------------------- |
+| Secretos de aplicación       | `.env` local (python-dotenv)                  |
+| Variables de infraestructura | Variables de entorno del entorno              |
+| Secretos de CI/CD            | Secrets del proveedor (p. ej. GitHub Actions) |
+
+## Reglas
+
+- El archivo `.env` está en `.gitignore`; solo se versiona `.env.example` (sin valores).
+- Comparte secretos con nuevos colaboradores **fuera de banda** (nunca por git, email plano ni chat público).
+- Rota credenciales periódicamente (sugerido cada 90 días) y de inmediato ante sospecha de fuga.
+- Si un secreto se commitea por error: **rota el secreto primero**, luego limpia la historia.
+
+## Ejemplos
+
+```bash
+# Copiar la plantilla de variables
+cp .env.example .env
+# Completar valores reales (que nunca se suben):
+# DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD, SECRET_KEY, DEBUG
+```
+
+## Comandos útiles
+
+```bash
+# Gestor de secretos dedicado: No aplica en la versión actual.
+# Los secretos se cargan desde .env con python-dotenv (load_dotenv en settings).
+```
+
+## Referencias
+
+- [SECURITY.md](../../SECURITY.md) — política de seguridad.
+- Documentación de python-dotenv.

--- a/docs/conventions/seo.md
+++ b/docs/conventions/seo.md
@@ -1,0 +1,41 @@
+# Convenciones de SEO
+
+> Metadatos y buenas prácticas de SEO en TechWorld Learning Platform.
+> **Última actualización**: 2026-07-02
+
+## Qué emite el head compartido
+
+Cada página debe proveer, a través del layout/head compartido:
+
+- `<title>` único y descriptivo.
+- `<meta name="description">`.
+- Open Graph: `og:title`, `og:description`, `og:image`, `og:url`, `og:type`.
+- Twitter Card: `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`.
+- `<link rel="canonical">`.
+- `<meta name="robots">` según la página.
+
+## Reglas de indexación
+
+| Tipo de página                 | robots          |
+| ------------------------------ | --------------- |
+| Públicas (landing, blog)       | `index, follow` |
+| Autenticación (login/registro) | `noindex`       |
+| Áreas privadas (dashboard)     | `noindex`       |
+
+## Reglas
+
+- Una sola etiqueta canónica por página.
+- Imagen OG con dimensiones recomendadas (1200×630).
+- URLs legibles y estables; evitar parámetros innecesarios.
+- `sitemap.xml` y `robots.txt` mantenidos al día.
+
+## Ejemplos
+
+```html
+<meta name="description" content="Descripción única de la página" />
+<meta property="og:image" content="{% static 'img/og-image.png' %}" />
+```
+
+## Referencias
+
+- Documentación de plantillas de Django (etiquetas `{% static %}` y `<head>` compartido).

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -1,0 +1,49 @@
+# Convenciones de testing
+
+> Cómo escribimos y ejecutamos tests en TechWorld Learning Platform.
+> **Última actualización**: 2026-07-02
+
+## Stack
+
+- **Framework de tests**: Django `TestCase` (opcionalmente pytest-django).
+- **Cobertura**: coverage.py (opcional; No aplica en la versión actual).
+- **Tests de sistema/E2E**: No aplica en la versión actual.
+
+## Tipos de test
+
+| Tipo          | Qué cubre                     | Carpeta              |
+| ------------- | ----------------------------- | -------------------- |
+| Unitarios     | Funciones/clases aisladas     | `<app>/tests.py`             |
+| Integración   | Interacción entre componentes | `<app>/tests.py`             |
+| E2E / sistema | Flujos completos de usuario   | No aplica en la versión actual |
+
+## Reglas
+
+- Todo cambio funcional se acompaña de tests.
+- Estructura **Arrange-Act-Assert** (AAA): preparar, ejecutar, verificar.
+- Un test verifica **una** cosa; nombres descriptivos del comportamiento esperado.
+- Los tests deben ser deterministas (sin dependencia de red, reloj o orden).
+- Cobertura mínima esperada: No aplica en la versión actual.
+
+## Ejemplos
+
+```python
+class RecursoTests(TestCase):
+    def test_comportamiento_esperado_cuando_condicion(self):
+        # Arrange
+        # Act
+        # Assert
+        ...
+```
+
+## Comandos útiles
+
+```bash
+python manage.py test                          # Ejecutar todos los tests
+coverage run manage.py test && coverage report # Con reporte de cobertura (opcional)
+# Modo watch: No aplica en la versión actual.
+```
+
+## Referencias
+
+- Documentación oficial de testing de Django.

--- a/docs/conventions/views-and-layouts.md
+++ b/docs/conventions/views-and-layouts.md
@@ -1,0 +1,40 @@
+# Convenciones de vistas y layouts
+
+> Cómo organizamos vistas, layouts y UI compartida en TechWorld Learning Platform.
+> **Última actualización**: 2026-07-02
+
+## Layouts
+
+| Layout                                | Uso                                         |
+| ------------------------------------- | ------------------------------------------- |
+| `templates/base.html`                 | Páginas públicas (landing, listado de cursos) |
+| `templates/base.html` (`users/`)      | Pantallas de autenticación (login/registro) |
+| `templates/base.html` + `templates/navbar.html` | Producto autenticado (área de cursos) |
+
+## Elementos compartidos
+
+- **Head compartido**: metadatos y SEO (ver [`seo.md`](seo.md)).
+- **Mensajes flash**: patrón único para notificaciones de éxito/error.
+- **Navegación**: header/menú reutilizable.
+
+## Reglas
+
+- Reutiliza parciales/componentes; no dupliques marcado.
+- Cada vista contempla sus estados: carga, vacío, error y éxito.
+- La UI sigue el [sistema de diseño](design-system.md).
+- Separa estructura (layout) de contenido (vista) de comportamiento.
+
+## Estructura
+
+```text
+templates/
+├── base.html                 # layout base (herencia de plantillas)
+└── navbar.html               # navegación reutilizable
+
+<app>/templates/<app>/        # vistas por recurso (p. ej. courses/, users/)
+```
+
+## Referencias
+
+- [`design-system.md`](design-system.md)
+- [`seo.md`](seo.md)

--- a/docs/decisions/0000-template.md
+++ b/docs/decisions/0000-template.md
@@ -1,0 +1,38 @@
+# NNNN. [Título de la decisión]
+
+- **Estado**: [Propuesta | Aceptada | Reemplazada por ADR-XXXX | Obsoleta]
+- **Fecha**: 2026-07-02
+- **Decisores**: [NOMBRES]
+
+## Contexto y problema
+
+[Describe el contexto y el problema que motiva la decisión. ¿Qué fuerzas están en
+juego (técnicas, de negocio, de equipo)? ¿Qué restricciones existen?]
+
+## Opciones consideradas
+
+- **[Opción A]** — [descripción breve].
+- **[Opción B]** — [descripción breve].
+- **[Opción C]** — [descripción breve].
+
+## Decisión
+
+[La opción elegida y la justificación. "Elegimos [Opción A] porque…"]
+
+## Consecuencias
+
+**Positivas:**
+
+- [Beneficio].
+
+**Negativas / costos:**
+
+- [Costo o desventaja asumida].
+
+**Neutras / a vigilar:**
+
+- [Efecto que conviene monitorear].
+
+## Referencias
+
+- [Enlaces a discusiones, issues, documentos o ADRs relacionados].

--- a/docs/decisions/0001-record-architecture-decisions.md
+++ b/docs/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,45 @@
+# 0001. Registrar las decisiones de arquitectura
+
+- **Estado**: Aceptada
+- **Fecha**: 2026-07-02
+- **Decisores**: Brayan Diaz C
+
+## Contexto y problema
+
+A medida que el proyecto evoluciona se toman decisiones de arquitectura cuyo
+contexto y motivación se pierden con el tiempo. Sin un registro, el equipo repite
+debates ya resueltos y las nuevas personas no entienden por qué el sistema es como
+es.
+
+## Opciones consideradas
+
+- **No documentar** — confiar en la memoria del equipo y el historial de commits.
+- **Documentar en una wiki** — fácil de editar pero desligado del código.
+- **Architecture Decision Records (ADRs)** — archivos versionados junto al código.
+
+## Decisión
+
+Adoptamos **Architecture Decision Records (ADRs)** ligeros (estilo MADR),
+versionados en `docs/decisions/`. Cada decisión relevante se documenta con la
+plantilla [`0000-template.md`](0000-template.md) y se numera secuencialmente.
+
+## Consecuencias
+
+**Positivas:**
+
+- El "por qué" de cada decisión queda registrado junto al código.
+- Las nuevas personas se ponen al día más rápido.
+- Se evita re-litigar decisiones ya tomadas.
+
+**Negativas / costos:**
+
+- Requiere disciplina para crear el ADR en el momento de decidir.
+
+**Neutras / a vigilar:**
+
+- Mantener el índice del [README](README.md) actualizado.
+
+## Referencias
+
+- [Documenting Architecture Decisions — Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+- [MADR — Markdown Architectural Decision Records](https://adr.github.io/madr/)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,39 @@
+# Decisiones de Arquitectura (ADRs)
+
+Esta carpeta registra las **decisiones de arquitectura** del proyecto mediante
+_Architecture Decision Records_ (ADRs): documentos cortos que capturan una
+decisión relevante, su contexto y sus consecuencias.
+
+## ¿Qué es un ADR y cuándo crear uno?
+
+Crea un ADR cuando tomes una decisión que sea **difícil o costosa de revertir**,
+afecte a varias partes del sistema, o que tu yo futuro (o un nuevo integrante)
+agradecerá tener documentada. Ejemplos: elegir base de datos, definir el modelo
+de autenticación, adoptar un patrón arquitectónico, cambiar de proveedor.
+
+No hace falta un ADR para decisiones triviales o fácilmente reversibles.
+
+## Convención de numeración y nombres
+
+- Archivos: `NNNN-titulo-en-kebab-case.md` (numeración secuencial empezando en `0001`).
+- La plantilla base es [`0000-template.md`](0000-template.md) — cópiala para crear uno nuevo.
+
+## Ciclo de estados
+
+```
+Propuesta → Aceptada → (eventualmente) Reemplazada por ADR-XXXX | Obsoleta
+```
+
+- **Propuesta**: en discusión.
+- **Aceptada**: decisión vigente.
+- **Reemplazada**: una decisión posterior la sustituye (enlaza al nuevo ADR).
+- **Obsoleta**: ya no aplica.
+
+Los ADRs son **inmutables** una vez aceptados: en lugar de editarlos, se crea uno
+nuevo que reemplace al anterior.
+
+## Índice
+
+| ADR                                           | Título                                   | Estado   |
+| --------------------------------------------- | ---------------------------------------- | -------- |
+| [0001](0001-record-architecture-decisions.md) | Registrar las decisiones de arquitectura | Aceptada |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,21 @@
+# Glosario
+
+Vocabulario compartido del dominio y del proyecto. Mantén las definiciones cortas
+y sin ambigüedad para que todo el equipo use los términos de la misma forma.
+
+| Término        | Definición                                                                                                                            |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Curso          | Contenido formativo que ofrece la plataforma. Modelo `Course` con título, descripción y duración en horas.                            |
+| Django ORM     | Capa de mapeo objeto-relacional de Django que traduce clases de modelo a tablas y permite consultar la base de datos con Python.      |
+| Estudiante     | Rol de usuario (`role="student"`) que se inscribe en cursos y sigue su progreso. Es el valor por defecto al registrarse.              |
+| Fixture        | Archivo JSON con datos iniciales que se carga con `python manage.py loaddata` para poblar la base de datos.                           |
+| Inscripción    | Relación entre un usuario y un curso. Modelo `Inscription` (tabla intermedia) con `progress` y `unique_together` para evitar duplicados. |
+| Instructor     | Rol de usuario (`role="instructor"`) asociado a la creación de cursos.                                                                |
+| Migración      | Archivo generado por Django que versiona los cambios del esquema de la base de datos (`makemigrations` / `migrate`).                 |
+| MTV            | Patrón Modelo-Template-Vista de Django: separa datos (Modelo), presentación (Template) y lógica de la petición (Vista).              |
+| PostgreSQL     | Sistema de base de datos relacional usado por el proyecto (motor `django.db.backends.postgresql`).                                   |
+| Progreso       | Porcentaje de avance de un estudiante en un curso. Campo `progress` (entero, por defecto 0) del modelo `Inscription`.                |
+| Usuario        | Persona registrada en la plataforma. Modelo propio `User` (no extiende `AbstractUser`) con username, email, contraseña y rol.        |
+
+> Convención: ordena los términos alfabéticamente y enlaza al documento donde se
+> detalla cada concepto cuando aplique.

--- a/docs/product/business-model.md
+++ b/docs/product/business-model.md
@@ -1,0 +1,69 @@
+# TechWorld Learning Platform — Modelo de Negocio
+
+> Marco: **Lean Canvas** (adaptado a un contexto educativo). Describe por qué existe el proyecto y cómo genera valor.
+> **Nota importante**: TechWorld Learning Platform es un **proyecto educativo de reforzamiento** para estudiantes de Inforcap, **no un producto comercial**. Es de uso formativo, **sin ánimo de lucro**, publicado bajo **licencia MIT**. Donde este marco pide precios, ingresos o rentabilidad, se indica que **no aplica** por tratarse de un proyecto educativo.
+> **Última actualización**: 2026-07-02
+
+## 1. Problema
+
+- **Problema principal**: quienes aprenden Django necesitan un ejemplo completo y realista que muestre, de principio a fin, cómo se construye un MVP web con el patrón MTV (Modelo-Template-Vista), y no solo fragmentos aislados de código.
+- **Problema secundario**: la teoría de modelos, relaciones (uno a muchos, tablas intermedias), migraciones, plantillas y formularios se entiende mejor con un dominio concreto que la conecta con un caso práctico (gestión de cursos e inscripciones).
+- **Alternativas actuales**: tutoriales sueltos, documentación oficial y ejercicios "de juguete" que rara vez integran usuarios, cursos, inscripciones y progreso en un mismo proyecto coherente.
+
+## 2. Segmentos de cliente
+
+> En este proyecto, "clientes" se entiende como **audiencia formativa**. No hay clientes de pago.
+
+| Segmento                    | Descripción                                                                                     | Notas                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Estudiantes de Inforcap     | Aprendices de Django que refuerzan sus conocimientos siguiendo el proyecto paso a paso.         | Audiencia principal / "early adopter" del material.       |
+| Instructores y docentes     | Personas que enseñan Django y usan el proyecto como material de apoyo o base para sus clases.   | Adaptan y extienden el ejemplo para sus grupos.           |
+
+- **Audiencia ideal**: estudiante de Inforcap con bases de Python que quiere construir su primer proyecto web full-stack con Django y entender el patrón MTV en un caso real.
+- **Primeros usuarios**: los propios grupos de reforzamiento de Inforcap guiados por el instructor.
+
+## 3. Propuesta de valor única
+
+- Un MVP educativo **completo y honesto**: muestra un flujo real (registro, inicio de sesión, listado de cursos, inscripción con control de duplicados y seguimiento de progreso) usando exclusivamente Django y el patrón MTV, sin capas innecesarias.
+- **Concepto de alto nivel**: "un proyecto guía tipo plataforma de cursos, para aprender Django MTV construyéndolo de verdad".
+
+## 4. Solución (el producto)
+
+| Módulo / Capacidad          | Qué resuelve                                                                                          |
+| --------------------------- | ---------------------------------------------------------------------------------------------------- |
+| App `users`                 | Registro de usuarios con contraseña hasheada (`make_password`) e inicio de sesión manual; enseña modelos propios y roles (estudiante / instructor). |
+| App `courses`               | Creación y listado de cursos; enseña modelos, migraciones y renderizado con plantillas.              |
+| Inscripciones y progreso    | Relación usuario–curso mediante el modelo `Inscription` (tabla intermedia con progreso y `unique_together`); enseña relaciones N–N con datos extra y validación de duplicados. |
+| Django Admin                | Panel de administración para gestionar usuarios, cursos e inscripciones sin escribir vistas propias. |
+
+## 5. Canales
+
+- Repositorio público en GitHub (`brayandiazc/inforcap-techworld-django`) con guía paso a paso.
+- Sesiones y material de reforzamiento de Inforcap.
+- Boca a boca entre estudiantes e instructores de la comunidad.
+
+## 6. Modelo de ingresos
+
+> **No aplica.** El proyecto es educativo y **sin ánimo de lucro**; se distribuye gratuitamente bajo **licencia MIT**. No existen planes, precios, suscripciones ni monetización de ningún tipo.
+
+## 7. Estructura de costos y rentabilidad
+
+> **No aplica como negocio.** Al ser un proyecto formativo y de código abierto, no hay estructura de ingresos ni objetivo de rentabilidad.
+
+- **Costos del proyecto**: se limitan al tiempo de desarrollo y mantenimiento voluntario del autor. Para ejecutarlo basta un entorno local con Python y PostgreSQL; no requiere infraestructura de pago.
+
+## 8. Métricas clave
+
+> Al ser educativo, las métricas relevantes son de **aprendizaje y adopción del material**, no comerciales.
+
+- **De aprendizaje**: estudiantes que completan la guía y logran levantar el proyecto localmente; comprensión del patrón MTV y de las relaciones entre modelos.
+- **De adopción**: estrellas / forks del repositorio, uso del proyecto como base en cursos y aportes de la comunidad.
+
+## 9. Ventaja competitiva
+
+- Proyecto real, coherente y mantenido por un instructor de Inforcap, pensado explícitamente para enseñar y con el código honesto sobre su propio estado (incluyendo su deuda técnica documentada, como la autenticación).
+
+## Decisiones pendientes
+
+- [ ] Definir hasta qué punto extender el proyecto como material sin perder su claridad didáctica.
+- [ ] Decidir si se documenta la migración de la autenticación propia al sistema de auth de Django como ejercicio guiado.

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -1,0 +1,64 @@
+# Roadmap — TechWorld Learning Platform
+
+> Estado y dirección del proyecto. Documento vivo.
+> **Última actualización**: 2026-07-02
+
+## Leyenda
+
+- ✅ Hecho
+- 🚧 En curso
+- 📋 Planificado
+- ⏸️ Diferido
+
+## Visión
+
+TechWorld Learning Platform aspira a ser un proyecto de referencia para aprender Django con el patrón MTV: un MVP claro, honesto y completo que evoluciona de forma incremental, incorporando buenas prácticas (autenticación estándar, pruebas, integración continua y despliegue) sin perder su valor didáctico para los estudiantes de Inforcap.
+
+## Estado actual
+
+Versión **1.0.0**: MVP funcional. Permite registrar usuarios (contraseña hasheada con `make_password`), iniciar sesión de forma manual (`check_password`), listar cursos, crear cursos e inscribirse en ellos con control de inscripción duplicada (`unique_together`) y campo de progreso. Stack: Python 3.10+, Django 5.1.3, PostgreSQL vía `psycopg2-binary`, plantillas Django + Bootstrap y configuración por variables de entorno con `python-dotenv`. Aún **no** hay pruebas reales, integración continua ni despliegue configurado, y la autenticación no usa todavía el sistema de sesiones de Django.
+
+## Por versión / fase
+
+### ✅ Fase 1 — v1.0.0: MVP funcional (Hecho)
+
+- [x] Modelo propio `User` con roles (estudiante / instructor).
+- [x] Registro de usuarios con contraseña hasheada.
+- [x] Inicio de sesión manual verificando el hash.
+- [x] Modelos `Course` e `Inscription` con relación usuario–curso y progreso.
+- [x] Listado y creación de cursos.
+- [x] Inscripción a cursos con control de duplicados (`unique_together`).
+- [x] Configuración por variables de entorno y carga de datos iniciales con fixtures.
+- [x] Django Admin para usuarios, cursos e inscripciones.
+
+### 🚧 Fase 2 — Consolidación y calidad (En curso)
+
+- [ ] 🚧 Unificar la autenticación con el sistema de Django (migrar a `AbstractUser` o al auth estándar, con sesiones persistentes) para resolver la deuda técnica del login/registro manual.
+- [ ] 📋 Agregar pruebas automatizadas (los archivos `tests.py` están vacíos hoy).
+- [ ] 📋 Asignar el instructor al crear un curso (hoy `create_course` no asocia instructor).
+
+### 📋 Fase 3 — Funcionalidades para el estudiante y el instructor (Planificado)
+
+- [ ] 📋 Vista de progreso del estudiante (avance por curso a partir del campo `progress` de `Inscription`).
+- [ ] 📋 Panel de analítica de cursos (inscripciones, progreso agregado) para instructores.
+
+### 📋 Fase 4 — Operación (Planificado)
+
+- [ ] 📋 Configurar integración continua (CI) para ejecutar las pruebas automáticamente.
+- [ ] 📋 Configurar el despliegue del proyecto.
+
+## Backlog / ideas sin agendar
+
+- Recuperación de contraseña y validaciones de formulario más completas.
+- Internacionalización (i18n) del proyecto.
+- Posible API REST para exponer cursos e inscripciones.
+
+## Fuera de alcance
+
+- Monetización, planes de pago o pasarelas de cobro: el proyecto es educativo y sin ánimo de lucro (licencia MIT).
+- Convertirlo en una SPA o añadir un framework JavaScript: se mantiene deliberadamente en el patrón MTV server-rendered por su valor didáctico.
+
+## Cómo se actualiza este documento
+
+- Revisar al cerrar cada versión/fase.
+- Las decisiones que cambian el rumbo se registran como ADRs en [`../decisions/`](../decisions/README.md).


### PR DESCRIPTION
## Resumen

Adopta la estructura de la plantilla [`project-starter-template-es`](https://github.com/brayandiazc/project-starter-template-es) en este repositorio existente, siguiendo el flujo para proyectos ya iniciados (copia selectiva, sin tocar el código ni el historial). Todo el contenido fue **adaptado a la realidad del proyecto** (Django 5.1 / MTV / PostgreSQL), reemplazando los placeholders con datos reales.

## Cambios

- **`docs/`**
  - `architecture/`: stack, arquitectura (con diagramas mermaid), modelo de datos (ERD real de `User`/`Course`/`Inscription`), autenticación, contrato de vistas HTTP y diseño.
  - `product/`: modelo (educativo, sin fines de lucro) y roadmap por fases.
  - `conventions/`: reglas reusables adaptadas a Django; se eliminaron `i18n.md` y `transactional-emails.md` por no aplicar.
  - `decisions/`: ADRs. `glossary.md` con términos del dominio.
- **Gobernanza**: `CONTRIBUTING`, `CODE_OF_CONDUCT`, `SECURITY`, `CHANGELOG` (v1.0.0), `LICENSE` (MIT), `.editorconfig`.
- **`.github/`**: plantillas de issues/PR, `dependabot.yml` (ecosistema `pip`), `FUNDING`, `labeler` y `ci.example.yml` (lint + tests con PostgreSQL para Django).
- **`.env.example`** específico de Django.
- **`README.md`**: nuevas secciones de Documentación, Contribuir y Licencia (merge manual, sin sobrescribir).

## Notas

Durante el llenado se documentaron con honestidad algunos hallazgos del código actual (deuda técnica): `login_view` redirige a una ruta `home` inexistente, el `<link>` a `styles.css` está comentado en `base.html`, y la autenticación usa un modelo propio en vez del sistema de Django. Quedan reflejados en `docs/architecture/auth.md` y en el roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)